### PR TITLE
docs: expand SoftDecisionTree.predict_proba docstring

### DIFF
--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -291,13 +291,20 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
         """
         Predict class probabilities.
 
+        Each probability is derived from the soft path through the tree:
+        every internal node routes a fraction of the input down each child,
+        so a sample's leaf class distributions are weighted by its
+        accumulated path probabilities.
+
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
+            Input samples. Cast to ``float32`` for the forward pass.
 
         Returns
         -------
         proba : ndarray of shape (n_samples, n_classes)
+            Class probabilities. Each row sums to 1.
         """
         check_is_fitted(self)
         X = check_array(X)


### PR DESCRIPTION
## 概要

#5 で要求された 3 点を `SoftDecisionTree.predict_proba` の docstring に追加します。

実は既存の docstring は完全に欠けてはおらず、shape のみ書かれた状態(Parameters / Returns セクションあり)でした。issue 本文の以下の項目が未記載のため拡張します:

- 入力 X の dtype(forward pass で `float32` に cast されること)
- 戻り値が「行ごとに合計 1」となる確率分布である旨
- 「probability is derived from the soft path through the tree」の一行説明

同ファイルの `fit()` メソッドの numpydoc スタイル(Parameters / Returns セクション)を踏襲しています。

Closes #5

## 動作確認

- 変更は **`neural_trees/decision_trees/soft_decision_tree.py` の 1 メソッド docstring のみ**(+7 行、コードロジック無変更)
- `python -c "import ast; ast.parse(...)"` で構文 OK
- gitleaks v8.30.1 でスキャン clean
- numpydoc/Sphinx で render される際の構造保持