### PR TITLE
chore: add development requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=7.0
+pytest-cov>=4.0
+ruff>=0.4


### PR DESCRIPTION
Fixes #15

## Summary
- Added `requirements-dev.txt` with the dev-only tools listed in CONTRIBUTING.
- Used loose minimum versions for pytest, pytest-cov, and ruff.

## Tests
- `uv pip compile requirements-dev.txt -q`
- `uv run --python 3.12 pytest tests/ -q`
- `git diff --check`

## Notes
- Kept the file exactly scoped to the issue request.