### PR TITLE
test: add reproducible soft decision tree training

### DIFF
--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -214,7 +214,7 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
         penalty_coef: float = 1e-3,
         device: str = "cpu",
         verbose: bool = False,
-        random_state: int | None = None,
+        random_state: Optional[int] = None,
     ):
         self.depth = depth
         self.max_epochs = max_epochs

--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -178,6 +178,8 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
         PyTorch device ("cpu" or "cuda").
     verbose : bool, default=False
         Whether to print training progress.
+    random_state : int or None, default=None
+        Seed for model initialization and shuffled mini-batches.
 
     Attributes
     ----------
@@ -212,6 +214,7 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
         penalty_coef: float = 1e-3,
         device: str = "cpu",
         verbose: bool = False,
+        random_state: int | None = None,
     ):
         self.depth = depth
         self.max_epochs = max_epochs
@@ -220,6 +223,7 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
         self.penalty_coef = penalty_coef
         self.device = device
         self.verbose = verbose
+        self.random_state = random_state
 
     def fit(self, X, y):
         """
@@ -241,6 +245,9 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
         self.n_features_in_ = X.shape[1]
         n_classes = len(self.classes_)
 
+        if self.random_state is not None:
+            torch.manual_seed(self.random_state)
+
         device = torch.device(self.device)
         X_t = torch.FloatTensor(X).to(device)
         y_t = torch.LongTensor(y_enc).to(device)
@@ -254,7 +261,16 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
 
         optimizer = torch.optim.Adam(self.model_.parameters(), lr=self.learning_rate)
         dataset = TensorDataset(X_t, y_t)
-        loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
+        generator = None
+        if self.random_state is not None:
+            generator = torch.Generator()
+            generator.manual_seed(self.random_state)
+        loader = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            generator=generator,
+        )
 
         self.training_history_: List[dict] = []
 

--- a/tests/test_soft_decision_tree.py
+++ b/tests/test_soft_decision_tree.py
@@ -72,3 +72,16 @@ def test_different_depths():
         sdt = SoftDecisionTree(depth=depth, max_epochs=10)
         sdt.fit(X, y)
         assert sdt.score(X, y) > 0.3
+
+
+def test_training_reproducible_with_random_state():
+    X, y = load_iris(return_X_y=True)
+    X_train, X_test, y_train, _ = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    first = SoftDecisionTree(random_state=0, depth=3, max_epochs=10)
+    second = SoftDecisionTree(random_state=0, depth=3, max_epochs=10)
+
+    first.fit(X_train, y_train)
+    second.fit(X_train, y_train)
+
+    assert np.array_equal(first.predict(X_test), second.predict(X_test))


### PR DESCRIPTION
Fixes #11

## Summary

Adds reproducible training support for `SoftDecisionTree` and a regression test that trains two trees with the same `random_state`.

## Changes

- Adds a `random_state` constructor argument.
- Seeds PyTorch model initialization and the shuffled DataLoader when `random_state` is provided.
- Documents the new parameter in the class docstring.
- Adds the requested Iris reproducibility test using `np.array_equal` on held-out predictions.

## Tests

- `uv run --python 3.12 --with pytest --with numpy --with scikit-learn --with torch pytest tests/test_soft_decision_tree.py -q` -> 8 passed
- `uv run --python 3.12 --with pytest --with numpy --with scikit-learn --with torch pytest tests/ -q` -> 14 passed
- `git diff --check`

## Notes

The issue-specified test requires `random_state=0`, so this PR includes the minimal implementation needed for that API to work.