### PR TITLE
Fix coverage target in CI workflow (alpaydin_ml -> neural_trees)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ -v --cov=alpaydin_ml --cov-report=xml
+          pytest tests/ -v --cov=neural_trees --cov-report=xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
The Tests workflow runs `pytest --cov=alpaydin_ml`, but the package is named
`neural_trees` (the name `alpaydin_ml` appears nowhere in the repo). Coverage
therefore measured a module that does not exist, so the report uploaded to
Codecov was empty.

This points `--cov` at the actual import package so coverage reflects the real
source tree. One-line change to `.github/workflows/tests.yml`; no source or
test changes.

Checklist:
- [x] Branch based on latest main
- [x] No source or test changes (CI config only)
- [x] ASCII-only, consistent with existing style