### PR TITLE
Docs: Colab badges, library citation, Limitations, predict_proba docstring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv/
 htmlcov/
 *.ipynb_checkpoints/
 .DS_Store
+examples/output/

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ python examples/01_iris_classification.py
 
 ## Notebooks
 
+[![Open 01 in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/cgrtml/neural-trees/blob/main/notebooks/01_soft_decision_trees.ipynb)
+[![Open 02 in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/cgrtml/neural-trees/blob/main/notebooks/02_classifier_comparison_tests.ipynb)
+
 - [`01_soft_decision_trees.ipynb`](notebooks/01_soft_decision_trees.ipynb): training, decision boundary visualization, comparison with CART
 - [`02_classifier_comparison_tests.ipynb`](notebooks/02_classifier_comparison_tests.ipynb): when to use which statistical test
 
@@ -173,6 +176,35 @@ If you use this library in academic work, please cite the original papers:
   year    = {1999}
 }
 ```
+
+To cite this implementation:
+
+```bibtex
+@software{temel_neural_trees,
+  author = {Temel, Cagri},
+  title  = {neural-trees: scikit-learn compatible Soft Decision Trees and Mixture of Experts},
+  year   = {2026},
+  url    = {https://github.com/cgrtml/neural-trees}
+}
+```
+
+## Limitations
+
+neural-trees is not the right tool for every problem:
+
+- **Very high-dimensional data.** Every internal node holds a dense weight
+  vector, so parameter count grows as `2^depth x n_features`. Beyond a few
+  thousand features, reduce dimensionality first or use a linear model.
+- **Streaming or online learning.** Training is batch only; there is no
+  `partial_fit`. Refit from scratch when new data arrives.
+- **Sub-millisecond inference.** The PyTorch backend adds per-call overhead.
+  For extreme latency budgets, export the learned gates and evaluate them in
+  plain numpy.
+- **Very large sample counts.** Training is full-batch gradient descent over
+  epochs, not an optimized tree-growing routine like CART. Millions of rows
+  will be slow on CPU.
+- **Categorical features.** There is no built-in encoding; sigmoid gates
+  expect continuous, scaled inputs. Encode and scale in a `Pipeline`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ Standard decision trees use hard splits, which makes them non-differentiable and
 - Performance often lands between CART and ensemble methods
 - The tree stays interpretable, you can still read off split decisions
 
+## Examples
+
+Runnable scripts in [`examples/`](examples):
+
+| Script | What it shows |
+|--------|---------------|
+| [`01_iris_classification.py`](examples/01_iris_classification.py) | Minimal train/test loop on Iris |
+| [`02_pipeline_with_scaler.py`](examples/02_pipeline_with_scaler.py) | `StandardScaler` + `SoftDecisionTree` in a `Pipeline`, 5-fold CV |
+| [`03_classifier_comparison.py`](examples/03_classifier_comparison.py) | Combined 5x2cv F test against CART |
+| [`04_decision_boundary.py`](examples/04_decision_boundary.py) | Decision boundary plot on `make_moons` |
+
+```bash
+python examples/01_iris_classification.py
+```
+
 ## Notebooks
 
 - [`01_soft_decision_trees.ipynb`](notebooks/01_soft_decision_trees.ipynb): training, decision boundary visualization, comparison with CART

--- a/examples/01_iris_classification.py
+++ b/examples/01_iris_classification.py
@@ -1,0 +1,20 @@
+"""
+Minimal end-to-end example: train a Soft Decision Tree on Iris.
+
+Run with:
+    python examples/01_iris_classification.py
+"""
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
+from neural_trees import SoftDecisionTree
+
+X, y = load_iris(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.3, stratify=y, random_state=42
+)
+
+model = SoftDecisionTree(depth=4, max_epochs=40, random_state=42)
+model.fit(X_train, y_train)
+
+print(f"Test accuracy: {model.score(X_test, y_test):.3f}")

--- a/examples/02_pipeline_with_scaler.py
+++ b/examples/02_pipeline_with_scaler.py
@@ -1,0 +1,28 @@
+"""
+Use SoftDecisionTree inside a scikit-learn Pipeline with StandardScaler,
+and report 5-fold cross-validated accuracy on the Wine dataset.
+
+Scaling matters here: the sigmoid gates saturate when raw feature scales
+differ by orders of magnitude, as they do in Wine.
+
+Run with:
+    python examples/02_pipeline_with_scaler.py
+"""
+from sklearn.datasets import load_wine
+from sklearn.model_selection import cross_val_score
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import SoftDecisionTree
+
+X, y = load_wine(return_X_y=True)
+
+pipe = Pipeline([
+    ("scaler", StandardScaler()),
+    ("model", SoftDecisionTree(depth=4, max_epochs=60, random_state=42)),
+])
+
+scores = cross_val_score(pipe, X, y, cv=5)
+
+print(f"Fold accuracies: {[round(s, 3) for s in scores]}")
+print(f"Mean accuracy:   {scores.mean():.3f} (+/- {scores.std():.3f})")

--- a/examples/03_classifier_comparison.py
+++ b/examples/03_classifier_comparison.py
@@ -1,0 +1,32 @@
+"""
+Compare a Soft Decision Tree against CART with Alpaydin's combined 5x2cv F test.
+
+The test asks whether the accuracy gap between the two models is larger than
+what the variance of resampling alone would explain.
+
+Run with:
+    python examples/03_classifier_comparison.py
+"""
+from sklearn.datasets import load_breast_cancer
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.tree import DecisionTreeClassifier
+
+from neural_trees import SoftDecisionTree, combined_5x2cv_f_test
+
+X, y = load_breast_cancer(return_X_y=True)
+
+soft_tree = Pipeline([
+    ("scaler", StandardScaler()),
+    ("model", SoftDecisionTree(depth=4, max_epochs=40, random_state=42)),
+])
+cart = DecisionTreeClassifier(max_depth=4, random_state=42)
+
+result = combined_5x2cv_f_test(soft_tree, cart, X, y)
+
+print(f"F statistic: {result.statistic:.4f}")
+print(f"p-value:     {result.p_value:.4f}")
+if result.reject_null:
+    print("Interpretation: the two classifiers differ significantly (p < 0.05).")
+else:
+    print("Interpretation: no significant difference; the gap is within resampling noise.")

--- a/examples/04_decision_boundary.py
+++ b/examples/04_decision_boundary.py
@@ -1,0 +1,45 @@
+"""
+Plot the decision boundary a Soft Decision Tree learns on make_moons.
+
+The boundary is smooth rather than axis-aligned and piecewise constant,
+which is the visible difference between soft and hard splits.
+
+Run with:
+    python examples/04_decision_boundary.py
+
+Writes examples/output/04_decision_boundary.png
+"""
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.datasets import make_moons
+
+from neural_trees import SoftDecisionTree
+
+X, y = make_moons(n_samples=400, noise=0.2, random_state=42)
+
+model = SoftDecisionTree(depth=4, max_epochs=40, random_state=42)
+model.fit(X, y)
+
+x_min, x_max = X[:, 0].min() - 0.5, X[:, 0].max() + 0.5
+y_min, y_max = X[:, 1].min() - 0.5, X[:, 1].max() + 0.5
+xx, yy = np.meshgrid(
+    np.linspace(x_min, x_max, 300), np.linspace(y_min, y_max, 300)
+)
+grid = np.c_[xx.ravel(), yy.ravel()]
+zz = model.predict_proba(grid)[:, 1].reshape(xx.shape)
+
+fig, ax = plt.subplots(figsize=(7, 5))
+contour = ax.contourf(xx, yy, zz, levels=20, cmap="RdBu_r", alpha=0.8)
+ax.contour(xx, yy, zz, levels=[0.5], colors="black", linewidths=1.2)
+ax.scatter(X[:, 0], X[:, 1], c=y, cmap="RdBu_r", edgecolors="k", s=25)
+ax.set_title(f"SoftDecisionTree(depth=4) on make_moons, accuracy {model.score(X, y):.3f}")
+fig.colorbar(contour, ax=ax, label="P(class 1)")
+
+out_path = Path(__file__).parent / "output" / "04_decision_boundary.png"
+out_path.parent.mkdir(parents=True, exist_ok=True)
+fig.savefig(out_path, dpi=150, bbox_inches="tight")
+print(f"Saved {out_path}")

--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -310,13 +310,22 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
         """
         Predict class probabilities.
 
+        Each sample reaches every leaf with some probability, so the returned
+        distribution is the path-probability weighted average of the leaf
+        distributions, P(y | x) = sum_l mu_l(x) Q_l(y). This is why the output
+        is smooth rather than the piecewise constant output of a hard tree.
+
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
+            Samples to score. Cast to float32 internally, so any numeric dtype
+            is accepted. Must have the same number of features seen in `fit`.
 
         Returns
         -------
         proba : ndarray of shape (n_samples, n_classes)
+            Class probabilities in the order of `self.classes_`. Each row sums
+            to 1.
         """
         check_is_fitted(self)
         X = check_array(X)


### PR DESCRIPTION
Four small documentation items:

- Colab badges for both notebooks, directly under the Notebooks heading
- A `@software` BibTeX entry so users can cite the implementation, alongside the existing paper citations
- A **Limitations** section stating where the library is the wrong tool (high dimensionality, streaming data, sub-millisecond inference, very large `n`, categorical features)
- `SoftDecisionTree.predict_proba` docstring now documents the accepted dtype, the column order, and where the probability comes from (the path-probability weighted mixture over leaves)

Closes #5
Closes #6
Closes #14
Closes #17