### PR TITLE
Fix HMoE autograd break and GAL bias loss, expand test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv/
 htmlcov/
 *.ipynb_checkpoints/
 .DS_Store
+examples/output/

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ python examples/01_iris_classification.py
 
 ## Notebooks
 
+[![Open 01 in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/cgrtml/neural-trees/blob/main/notebooks/01_soft_decision_trees.ipynb)
+[![Open 02 in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/cgrtml/neural-trees/blob/main/notebooks/02_classifier_comparison_tests.ipynb)
+
 - [`01_soft_decision_trees.ipynb`](notebooks/01_soft_decision_trees.ipynb): training, decision boundary visualization, comparison with CART
 - [`02_classifier_comparison_tests.ipynb`](notebooks/02_classifier_comparison_tests.ipynb): when to use which statistical test
 
@@ -173,6 +176,35 @@ If you use this library in academic work, please cite the original papers:
   year    = {1999}
 }
 ```
+
+To cite this implementation:
+
+```bibtex
+@software{temel_neural_trees,
+  author = {Temel, Cagri},
+  title  = {neural-trees: scikit-learn compatible Soft Decision Trees and Mixture of Experts},
+  year   = {2026},
+  url    = {https://github.com/cgrtml/neural-trees}
+}
+```
+
+## Limitations
+
+neural-trees is not the right tool for every problem:
+
+- **Very high-dimensional data.** Every internal node holds a dense weight
+  vector, so parameter count grows as `2^depth x n_features`. Beyond a few
+  thousand features, reduce dimensionality first or use a linear model.
+- **Streaming or online learning.** Training is batch only; there is no
+  `partial_fit`. Refit from scratch when new data arrives.
+- **Sub-millisecond inference.** The PyTorch backend adds per-call overhead.
+  For extreme latency budgets, export the learned gates and evaluate them in
+  plain numpy.
+- **Very large sample counts.** Training is full-batch gradient descent over
+  epochs, not an optimized tree-growing routine like CART. Millions of rows
+  will be slow on CPU.
+- **Categorical features.** There is no built-in encoding; sigmoid gates
+  expect continuous, scaled inputs. Encode and scale in a `Pipeline`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ Standard decision trees use hard splits, which makes them non-differentiable and
 - Performance often lands between CART and ensemble methods
 - The tree stays interpretable, you can still read off split decisions
 
+## Examples
+
+Runnable scripts in [`examples/`](examples):
+
+| Script | What it shows |
+|--------|---------------|
+| [`01_iris_classification.py`](examples/01_iris_classification.py) | Minimal train/test loop on Iris |
+| [`02_pipeline_with_scaler.py`](examples/02_pipeline_with_scaler.py) | `StandardScaler` + `SoftDecisionTree` in a `Pipeline`, 5-fold CV |
+| [`03_classifier_comparison.py`](examples/03_classifier_comparison.py) | Combined 5x2cv F test against CART |
+| [`04_decision_boundary.py`](examples/04_decision_boundary.py) | Decision boundary plot on `make_moons` |
+
+```bash
+python examples/01_iris_classification.py
+```
+
 ## Notebooks
 
 - [`01_soft_decision_trees.ipynb`](notebooks/01_soft_decision_trees.ipynb): training, decision boundary visualization, comparison with CART

--- a/examples/01_iris_classification.py
+++ b/examples/01_iris_classification.py
@@ -1,0 +1,20 @@
+"""
+Minimal end-to-end example: train a Soft Decision Tree on Iris.
+
+Run with:
+    python examples/01_iris_classification.py
+"""
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
+from neural_trees import SoftDecisionTree
+
+X, y = load_iris(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.3, stratify=y, random_state=42
+)
+
+model = SoftDecisionTree(depth=4, max_epochs=40, random_state=42)
+model.fit(X_train, y_train)
+
+print(f"Test accuracy: {model.score(X_test, y_test):.3f}")

--- a/examples/02_pipeline_with_scaler.py
+++ b/examples/02_pipeline_with_scaler.py
@@ -1,0 +1,28 @@
+"""
+Use SoftDecisionTree inside a scikit-learn Pipeline with StandardScaler,
+and report 5-fold cross-validated accuracy on the Wine dataset.
+
+Scaling matters here: the sigmoid gates saturate when raw feature scales
+differ by orders of magnitude, as they do in Wine.
+
+Run with:
+    python examples/02_pipeline_with_scaler.py
+"""
+from sklearn.datasets import load_wine
+from sklearn.model_selection import cross_val_score
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import SoftDecisionTree
+
+X, y = load_wine(return_X_y=True)
+
+pipe = Pipeline([
+    ("scaler", StandardScaler()),
+    ("model", SoftDecisionTree(depth=4, max_epochs=60, random_state=42)),
+])
+
+scores = cross_val_score(pipe, X, y, cv=5)
+
+print(f"Fold accuracies: {[round(s, 3) for s in scores]}")
+print(f"Mean accuracy:   {scores.mean():.3f} (+/- {scores.std():.3f})")

--- a/examples/03_classifier_comparison.py
+++ b/examples/03_classifier_comparison.py
@@ -1,0 +1,32 @@
+"""
+Compare a Soft Decision Tree against CART with Alpaydin's combined 5x2cv F test.
+
+The test asks whether the accuracy gap between the two models is larger than
+what the variance of resampling alone would explain.
+
+Run with:
+    python examples/03_classifier_comparison.py
+"""
+from sklearn.datasets import load_breast_cancer
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.tree import DecisionTreeClassifier
+
+from neural_trees import SoftDecisionTree, combined_5x2cv_f_test
+
+X, y = load_breast_cancer(return_X_y=True)
+
+soft_tree = Pipeline([
+    ("scaler", StandardScaler()),
+    ("model", SoftDecisionTree(depth=4, max_epochs=40, random_state=42)),
+])
+cart = DecisionTreeClassifier(max_depth=4, random_state=42)
+
+result = combined_5x2cv_f_test(soft_tree, cart, X, y)
+
+print(f"F statistic: {result.statistic:.4f}")
+print(f"p-value:     {result.p_value:.4f}")
+if result.reject_null:
+    print("Interpretation: the two classifiers differ significantly (p < 0.05).")
+else:
+    print("Interpretation: no significant difference; the gap is within resampling noise.")

--- a/examples/04_decision_boundary.py
+++ b/examples/04_decision_boundary.py
@@ -1,0 +1,45 @@
+"""
+Plot the decision boundary a Soft Decision Tree learns on make_moons.
+
+The boundary is smooth rather than axis-aligned and piecewise constant,
+which is the visible difference between soft and hard splits.
+
+Run with:
+    python examples/04_decision_boundary.py
+
+Writes examples/output/04_decision_boundary.png
+"""
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.datasets import make_moons
+
+from neural_trees import SoftDecisionTree
+
+X, y = make_moons(n_samples=400, noise=0.2, random_state=42)
+
+model = SoftDecisionTree(depth=4, max_epochs=40, random_state=42)
+model.fit(X, y)
+
+x_min, x_max = X[:, 0].min() - 0.5, X[:, 0].max() + 0.5
+y_min, y_max = X[:, 1].min() - 0.5, X[:, 1].max() + 0.5
+xx, yy = np.meshgrid(
+    np.linspace(x_min, x_max, 300), np.linspace(y_min, y_max, 300)
+)
+grid = np.c_[xx.ravel(), yy.ravel()]
+zz = model.predict_proba(grid)[:, 1].reshape(xx.shape)
+
+fig, ax = plt.subplots(figsize=(7, 5))
+contour = ax.contourf(xx, yy, zz, levels=20, cmap="RdBu_r", alpha=0.8)
+ax.contour(xx, yy, zz, levels=[0.5], colors="black", linewidths=1.2)
+ax.scatter(X[:, 0], X[:, 1], c=y, cmap="RdBu_r", edgecolors="k", s=25)
+ax.set_title(f"SoftDecisionTree(depth=4) on make_moons, accuracy {model.score(X, y):.3f}")
+fig.colorbar(contour, ax=ax, label="P(class 1)")
+
+out_path = Path(__file__).parent / "output" / "04_decision_boundary.png"
+out_path.parent.mkdir(parents=True, exist_ok=True)
+fig.savefig(out_path, dpi=150, bbox_inches="tight")
+print(f"Saved {out_path}")

--- a/neural_trees/__init__.py
+++ b/neural_trees/__init__.py
@@ -17,11 +17,17 @@ from neural_trees.statistical_tests.classifier_comparison import (
     paired_t_test,
 )
 from neural_trees.mixture_of_experts.hierarchical_moe import HierarchicalMixtureOfExperts
+from neural_trees.classical.multilayer_perceptron import GALNetwork
+from neural_trees.classical.k_nearest_neighbors import WeightedKNN
+from neural_trees.classical.naive_bayes import NaiveBayesClassifier
 
 __all__ = [
     "SoftDecisionTree",
     "OmnivariateDecisionTree",
     "HierarchicalMixtureOfExperts",
+    "GALNetwork",
+    "WeightedKNN",
+    "NaiveBayesClassifier",
     "combined_5x2cv_f_test",
     "mcnemar_test",
     "paired_t_test",

--- a/neural_trees/classical/multilayer_perceptron.py
+++ b/neural_trees/classical/multilayer_perceptron.py
@@ -17,13 +17,19 @@ Key idea:
 """
 
 import numpy as np
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ImportError as exc:  # pragma: no cover - exercised only without torch
+    raise ImportError(
+        "neural-trees requires PyTorch. Install it with: pip install torch "
+        "(see https://pytorch.org/get-started/locally/ for platform specific wheels)."
+    ) from exc
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
-from typing import List
+from typing import List, Optional
 
 
 class GALNetwork(BaseEstimator, ClassifierMixin):
@@ -50,6 +56,9 @@ class GALNetwork(BaseEstimator, ClassifierMixin):
         How often (in epochs) to check growth/pruning conditions.
     device : str, default="cpu"
     verbose : bool, default=False
+    random_state : int or None, default=None
+        Seed for weight initialization and for the units added during growth.
+        Set it for reproducible architectures.
 
     References
     ----------
@@ -68,6 +77,7 @@ class GALNetwork(BaseEstimator, ClassifierMixin):
         check_interval: int = 5,
         device: str = "cpu",
         verbose: bool = False,
+        random_state: Optional[int] = None,
     ):
         self.initial_hidden = initial_hidden
         self.max_hidden = max_hidden
@@ -78,6 +88,7 @@ class GALNetwork(BaseEstimator, ClassifierMixin):
         self.check_interval = check_interval
         self.device = device
         self.verbose = verbose
+        self.random_state = random_state
 
     def _build_model(self, n_features: int, n_hidden: int, n_classes: int) -> nn.Sequential:
         return nn.Sequential(
@@ -88,6 +99,8 @@ class GALNetwork(BaseEstimator, ClassifierMixin):
 
     def fit(self, X, y):
         X, y = check_X_y(X, y)
+        if self.random_state is not None:
+            torch.manual_seed(self.random_state)
         self.le_ = LabelEncoder()
         y_enc = self.le_.fit_transform(y)
         self.classes_ = self.le_.classes_
@@ -102,8 +115,9 @@ class GALNetwork(BaseEstimator, ClassifierMixin):
         model = self._build_model(self.n_features_in_, n_hidden, n_classes).to(device)
         self.architecture_history_: List[dict] = []
 
+        optimizer = torch.optim.SGD(model.parameters(), lr=self.learning_rate)
+
         for epoch in range(self.max_epochs):
-            optimizer = torch.optim.SGD(model.parameters(), lr=self.learning_rate)
             model.train()
             optimizer.zero_grad()
             logits = model(X_t)
@@ -138,11 +152,14 @@ class GALNetwork(BaseEstimator, ClassifierMixin):
                     model[2].weight.data = W2
                     model[2].bias.data = b2
 
+                    optimizer = torch.optim.SGD(model.parameters(), lr=self.learning_rate)
+
                     if self.verbose:
                         print(f"Epoch {epoch+1}: Pruned to {n_hidden} hidden units")
 
                 # Grow if error is high
                 elif error > self.grow_threshold and n_hidden < self.max_hidden:
+                    b2_old = model[2].bias.data.clone()
                     W1_new = torch.cat([
                         model[0].weight.data,
                         torch.randn(1, self.n_features_in_, device=device) * 0.1
@@ -158,6 +175,9 @@ class GALNetwork(BaseEstimator, ClassifierMixin):
                     model[0].weight.data = W1_new
                     model[0].bias.data = b1_new
                     model[2].weight.data = W2_new
+                    model[2].bias.data = b2_old
+
+                    optimizer = torch.optim.SGD(model.parameters(), lr=self.learning_rate)
 
                     if self.verbose:
                         print(f"Epoch {epoch+1}: Grew to {n_hidden} hidden units")

--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -23,9 +23,15 @@ Key idea:
 """
 
 import numpy as np
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ImportError as exc:  # pragma: no cover - exercised only without torch
+    raise ImportError(
+        "neural-trees requires PyTorch. Install it with: pip install torch "
+        "(see https://pytorch.org/get-started/locally/ for platform specific wheels)."
+    ) from exc
 from torch.utils.data import DataLoader, TensorDataset
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.preprocessing import LabelEncoder

--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -310,13 +310,22 @@ class SoftDecisionTree(BaseEstimator, ClassifierMixin):
         """
         Predict class probabilities.
 
+        Each sample reaches every leaf with some probability, so the returned
+        distribution is the path-probability weighted average of the leaf
+        distributions, P(y | x) = sum_l mu_l(x) Q_l(y). This is why the output
+        is smooth rather than the piecewise constant output of a hard tree.
+
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
+            Samples to score. Cast to float32 internally, so any numeric dtype
+            is accepted. Must have the same number of features seen in `fit`.
 
         Returns
         -------
         proba : ndarray of shape (n_samples, n_classes)
+            Class probabilities in the order of `self.classes_`. Each row sums
+            to 1.
         """
         check_is_fitted(self)
         X = check_array(X)

--- a/neural_trees/mixture_of_experts/hierarchical_moe.py
+++ b/neural_trees/mixture_of_experts/hierarchical_moe.py
@@ -22,9 +22,15 @@ Architecture (depth=2, branching=2):
 """
 
 import numpy as np
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ImportError as exc:  # pragma: no cover - exercised only without torch
+    raise ImportError(
+        "neural-trees requires PyTorch. Install it with: pip install torch "
+        "(see https://pytorch.org/get-started/locally/ for platform specific wheels)."
+    ) from exc
 from torch.utils.data import DataLoader, TensorDataset
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.preprocessing import LabelEncoder
@@ -108,27 +114,29 @@ class _HMoEModule(nn.Module):
         """
         batch_size = x.size(0)
         b = self.branching_factor
-
-        # Initialize gate node weights: root has weight 1
         n_gates = len(self.gates)
-        gate_weights = torch.zeros(batch_size, n_gates + self.n_experts, device=x.device)
-        gate_weights[:, 0] = 1.0
+        n_nodes = n_gates + self.n_experts
+
+        # Node weights are kept in a list rather than written into a single
+        # preallocated tensor: in-place index assignment bumps the version of
+        # the shared storage that autograd saved for the multiplication
+        # backward pass, which makes loss.backward() raise.
+        node_weights = [None] * n_nodes
+        node_weights[0] = torch.ones(batch_size, device=x.device)
 
         for gate_idx in range(n_gates):
             gate_out = self.gates[gate_idx](x)  # (batch, b)
+            parent_weight = node_weights[gate_idx]
             for child in range(b):
                 child_idx = b * gate_idx + child + 1
-                if child_idx < n_gates:
-                    gate_weights[:, child_idx] = gate_weights[:, gate_idx] * gate_out[:, child]
-                else:
-                    # This child is a leaf
-                    leaf_idx = child_idx - n_gates
-                    if leaf_idx < self.n_experts:
-                        gate_weights[:, n_gates + leaf_idx] = (
-                            gate_weights[:, gate_idx] * gate_out[:, child]
-                        )
+                if child_idx < n_nodes:
+                    node_weights[child_idx] = parent_weight * gate_out[:, child]
 
-        return gate_weights[:, n_gates:]  # (batch, n_experts)
+        leaf_weights = [
+            w if w is not None else torch.zeros(batch_size, device=x.device)
+            for w in node_weights[n_gates:]
+        ]
+        return torch.stack(leaf_weights, dim=1)  # (batch, n_experts)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -173,6 +181,8 @@ class HierarchicalMixtureOfExperts(BaseEstimator, ClassifierMixin):
     batch_size : int, default=64
     device : str, default="cpu"
     verbose : bool, default=False
+    random_state : int or None, default=None
+        Seed for weight initialization and shuffled mini-batches.
 
     Examples
     --------
@@ -202,6 +212,7 @@ class HierarchicalMixtureOfExperts(BaseEstimator, ClassifierMixin):
         batch_size: int = 64,
         device: str = "cpu",
         verbose: bool = False,
+        random_state: Optional[int] = None,
     ):
         self.depth = depth
         self.branching_factor = branching_factor
@@ -213,9 +224,12 @@ class HierarchicalMixtureOfExperts(BaseEstimator, ClassifierMixin):
         self.batch_size = batch_size
         self.device = device
         self.verbose = verbose
+        self.random_state = random_state
 
     def fit(self, X, y):
         X, y = check_X_y(X, y)
+        if self.random_state is not None:
+            torch.manual_seed(self.random_state)
         self.le_ = LabelEncoder()
         y_enc = self.le_.fit_transform(y)
         self.classes_ = self.le_.classes_
@@ -236,7 +250,16 @@ class HierarchicalMixtureOfExperts(BaseEstimator, ClassifierMixin):
         ).to(device)
 
         optimizer = torch.optim.Adam(self.model_.parameters(), lr=self.learning_rate)
-        loader = DataLoader(TensorDataset(X_t, y_t), batch_size=self.batch_size, shuffle=True)
+        generator = None
+        if self.random_state is not None:
+            generator = torch.Generator()
+            generator.manual_seed(self.random_state)
+        loader = DataLoader(
+            TensorDataset(X_t, y_t),
+            batch_size=self.batch_size,
+            shuffle=True,
+            generator=generator,
+        )
 
         self.training_history_: List[dict] = []
 

--- a/tests/test_gal_network.py
+++ b/tests/test_gal_network.py
@@ -1,0 +1,75 @@
+"""Tests for the GAL (Grow and Learn) constructive network."""
+import numpy as np
+import pytest
+from sklearn.base import clone
+from sklearn.datasets import load_iris
+from sklearn.model_selection import GridSearchCV, train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import GALNetwork
+
+
+@pytest.fixture(scope="module")
+def iris_split():
+    X, y = load_iris(return_X_y=True)
+    return train_test_split(X, y, test_size=0.3, stratify=y, random_state=0)
+
+
+def test_fit_predict_shapes(iris_split):
+    X_train, X_test, y_train, y_test = iris_split
+    gal = GALNetwork(max_epochs=60, random_state=0)
+    gal.fit(X_train, y_train)
+
+    preds = gal.predict(X_test)
+    assert preds.shape == y_test.shape
+    assert set(preds).issubset(set(np.unique(y_train)))
+
+    proba = gal.predict_proba(X_test)
+    assert proba.shape == (len(X_test), 3)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-5)
+
+
+def test_architecture_grows_and_is_recorded(iris_split):
+    X_train, _, y_train, _ = iris_split
+    gal = GALNetwork(initial_hidden=2, max_hidden=8, max_epochs=60, random_state=0)
+    gal.fit(X_train, y_train)
+
+    assert len(gal.architecture_history_) == 60
+    assert all({"epoch", "n_hidden", "error"} <= set(h) for h in gal.architecture_history_)
+    assert 1 <= gal.n_hidden_final_ <= 8
+    # Growth is the point of GAL: the network should not stay at its seed size
+    # while the error is above grow_threshold.
+    assert gal.n_hidden_final_ > 2
+
+
+def test_get_params_set_params_roundtrip():
+    gal = GALNetwork(initial_hidden=3, learning_rate=0.05)
+    params = gal.get_params()
+    assert params["initial_hidden"] == 3
+
+    gal.set_params(initial_hidden=5)
+    assert gal.get_params()["initial_hidden"] == 5
+    assert clone(gal).get_params()["initial_hidden"] == 5
+
+
+def test_works_in_pipeline_and_grid_search(iris_split):
+    X_train, _, y_train, _ = iris_split
+    pipe = Pipeline([
+        ("scaler", StandardScaler()),
+        ("gal", GALNetwork(max_epochs=20, random_state=0)),
+    ])
+    search = GridSearchCV(pipe, {"gal__initial_hidden": [2, 4]}, cv=2)
+    search.fit(X_train, y_train)
+
+    assert search.best_params_["gal__initial_hidden"] in (2, 4)
+    assert 0.0 <= search.best_score_ <= 1.0
+
+
+def test_random_state_makes_training_reproducible(iris_split):
+    X_train, X_test, y_train, _ = iris_split
+    first = GALNetwork(max_epochs=30, random_state=7).fit(X_train, y_train)
+    second = GALNetwork(max_epochs=30, random_state=7).fit(X_train, y_train)
+
+    assert first.n_hidden_final_ == second.n_hidden_final_
+    assert np.array_equal(first.predict(X_test), second.predict(X_test))

--- a/tests/test_hierarchical_moe.py
+++ b/tests/test_hierarchical_moe.py
@@ -1,0 +1,144 @@
+"""Tests for the Hierarchical Mixture of Experts."""
+import numpy as np
+import pytest
+import torch
+from sklearn.base import clone
+from sklearn.datasets import load_wine, make_classification
+from sklearn.model_selection import train_test_split
+from sklearn.neural_network import MLPClassifier
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import HierarchicalMixtureOfExperts
+
+
+@pytest.fixture(scope="module")
+def wine_split():
+    X, y = load_wine(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.3, stratify=y, random_state=0
+    )
+    scaler = StandardScaler().fit(X_train)
+    return scaler.transform(X_train), scaler.transform(X_test), y_train, y_test
+
+
+@pytest.mark.parametrize("depth,branching_factor", [(1, 2), (2, 2), (2, 4)])
+def test_fit_predict_across_tree_shapes(wine_split, depth, branching_factor):
+    X_train, X_test, y_train, y_test = wine_split
+    moe = HierarchicalMixtureOfExperts(
+        depth=depth, branching_factor=branching_factor, max_epochs=40, random_state=0
+    )
+    moe.fit(X_train, y_train)
+
+    assert moe.model_.n_experts == branching_factor ** depth
+    proba = moe.predict_proba(X_test)
+    assert proba.shape == (len(X_test), 3)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-5)
+    assert set(moe.predict(X_test)).issubset(set(np.unique(y_train)))
+
+
+def test_leaf_weights_form_a_distribution(wine_split):
+    """Gating weights over experts must sum to 1 for every sample."""
+    X_train, _, y_train, _ = wine_split
+    moe = HierarchicalMixtureOfExperts(depth=2, max_epochs=5, random_state=0).fit(
+        X_train, y_train
+    )
+    moe.model_.eval()
+    with torch.no_grad():
+        weights = moe.model_._compute_leaf_weights(torch.FloatTensor(X_train))
+
+    assert weights.shape == (len(X_train), moe.model_.n_experts)
+    assert (weights >= 0).all()
+    np.testing.assert_allclose(weights.sum(dim=1).numpy(), 1.0, atol=1e-5)
+
+
+def test_single_class_target():
+    """Degenerate but legal input: a target with only one class."""
+    X, _ = make_classification(n_samples=80, n_features=6, n_informative=4, random_state=0)
+    y = np.zeros(len(X), dtype=int)
+
+    moe = HierarchicalMixtureOfExperts(depth=1, max_epochs=5, random_state=0).fit(X, y)
+
+    assert list(moe.classes_) == [0]
+    assert moe.predict_proba(X).shape == (len(X), 1)
+    assert np.array_equal(moe.predict(X), y)
+
+
+@pytest.mark.parametrize("dropout_rate", [0.0, 0.9])
+def test_extreme_dropout_rates_still_train(wine_split, dropout_rate):
+    X_train, X_test, y_train, y_test = wine_split
+    moe = HierarchicalMixtureOfExperts(
+        depth=2, dropout_rate=dropout_rate, max_epochs=40, random_state=0
+    ).fit(X_train, y_train)
+
+    assert np.isfinite([h["loss"] for h in moe.training_history_]).all()
+    assert moe.score(X_test, y_test) > 0.3  # above the majority-class floor
+
+
+def test_dropout_is_active_in_training_mode_only(wine_split):
+    """Dropout must perturb the forward pass while training and not at predict time."""
+    X_train, _, y_train, _ = wine_split
+    moe = HierarchicalMixtureOfExperts(
+        depth=2, dropout_rate=0.5, max_epochs=5, random_state=0
+    ).fit(X_train, y_train)
+    batch = torch.FloatTensor(X_train[:16])
+
+    moe.model_.train()
+    with torch.no_grad():
+        stochastic = [moe.model_(batch).numpy() for _ in range(2)]
+    assert not np.allclose(stochastic[0], stochastic[1])
+
+    np.testing.assert_allclose(moe.predict_proba(X_train[:16]), moe.predict_proba(X_train[:16]))
+
+
+def test_dropout_does_not_worsen_the_generalization_gap():
+    """
+    Regression guard, not a proof: averaged over seeds, gating dropout should
+    not widen the train-test gap on a noisy toy problem. The effect is small
+    because dropout here applies to gating activations only, not to experts.
+    """
+    X, y = make_classification(
+        n_samples=160, n_features=20, n_informative=5, n_redundant=0,
+        flip_y=0.10, class_sep=0.8, random_state=0,
+    )
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.4, stratify=y, random_state=0
+    )
+    scaler = StandardScaler().fit(X_train)
+    X_train, X_test = scaler.transform(X_train), scaler.transform(X_test)
+
+    def mean_gap(dropout_rate):
+        gaps = []
+        for seed in range(3):
+            moe = HierarchicalMixtureOfExperts(
+                depth=2, gate_hidden=64, expert_hidden=64, dropout_rate=dropout_rate,
+                max_epochs=120, random_state=seed,
+            ).fit(X_train, y_train)
+            gaps.append(moe.score(X_train, y_train) - moe.score(X_test, y_test))
+        return float(np.mean(gaps))
+
+    assert mean_gap(0.5) <= mean_gap(0.0) + 0.05
+
+
+def test_competitive_with_mlp_on_wine(wine_split):
+    """The mixture should land in the same league as a comparable MLP."""
+    X_train, X_test, y_train, y_test = wine_split
+    moe = HierarchicalMixtureOfExperts(depth=2, max_epochs=150, random_state=0).fit(
+        X_train, y_train
+    )
+    mlp = MLPClassifier(hidden_layer_sizes=(64,), max_iter=1000, random_state=0).fit(
+        X_train, y_train
+    )
+
+    assert moe.score(X_test, y_test) >= mlp.score(X_test, y_test) - 0.15
+
+
+def test_pipeline_and_clone_compatible():
+    X, y = load_wine(return_X_y=True)
+    pipe = Pipeline([
+        ("scaler", StandardScaler()),
+        ("moe", HierarchicalMixtureOfExperts(depth=1, max_epochs=5, random_state=0)),
+    ])
+    pipe.fit(X, y)
+    assert 0.0 <= pipe.score(X, y) <= 1.0
+    assert clone(pipe).named_steps["moe"].get_params()["depth"] == 1

--- a/tests/test_soft_decision_tree.py
+++ b/tests/test_soft_decision_tree.py
@@ -92,3 +92,40 @@ def test_training_reproducible_with_random_state():
     second.fit(X_train, y_train)
 
     assert np.array_equal(first.predict(X_test), second.predict(X_test))
+
+
+def test_depth_one_single_split():
+    """A depth=1 tree is one split and two leaves, and must still train."""
+    from sklearn.datasets import make_classification
+
+    X, y = make_classification(
+        n_samples=200, n_features=6, n_informative=4, n_classes=2, random_state=0
+    )
+    X_train, X_test, y_train, _ = train_test_split(X, y, test_size=0.25, random_state=0)
+
+    sdt = SoftDecisionTree(depth=1, max_epochs=20, random_state=0)
+    sdt.fit(X_train, y_train)
+    preds = sdt.predict(X_test)
+
+    assert preds.shape == (X_test.shape[0],)
+    assert set(preds).issubset(set(np.unique(y_train)))
+    assert sdt.get_leaf_distributions().shape == (2, 2)
+    assert len(sdt.get_split_weights()) == 1
+
+
+def test_pipeline_and_grid_search_compatible():
+    """The estimator must survive clone(), Pipeline, and GridSearchCV."""
+    from sklearn.model_selection import GridSearchCV
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    X, y = load_iris(return_X_y=True)
+    pipe = Pipeline([
+        ("scaler", StandardScaler()),
+        ("model", SoftDecisionTree(depth=2, max_epochs=5, random_state=0)),
+    ])
+    search = GridSearchCV(pipe, {"model__depth": [2, 3]}, cv=2)
+    search.fit(X, y)
+
+    assert search.best_params_["model__depth"] in (2, 3)
+    assert 0.0 <= search.best_score_ <= 1.0

--- a/tests/test_torch_import_error.py
+++ b/tests/test_torch_import_error.py
@@ -1,0 +1,27 @@
+"""The import error must name PyTorch instead of a bare ModuleNotFoundError."""
+import importlib
+import sys
+
+import pytest
+
+TORCH_BACKED_MODULES = [
+    "neural_trees.decision_trees.soft_decision_tree",
+    "neural_trees.mixture_of_experts.hierarchical_moe",
+    "neural_trees.classical.multilayer_perceptron",
+]
+
+
+@pytest.mark.parametrize("module_name", TORCH_BACKED_MODULES)
+def test_missing_torch_raises_actionable_import_error(module_name, monkeypatch):
+    # Setting the entry to None makes `import torch` fail the way it would on a
+    # machine without PyTorch installed.
+    monkeypatch.setitem(sys.modules, "torch", None)
+    monkeypatch.setitem(sys.modules, "torch.nn", None)
+    monkeypatch.setitem(sys.modules, "torch.nn.functional", None)
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    with pytest.raises(ImportError, match="pip install torch"):
+        importlib.import_module(module_name)
+
+    # Leave a clean module table for the rest of the session.
+    sys.modules.pop(module_name, None)


### PR DESCRIPTION
Two correctness bugs surfaced while writing the coverage asked for in #2.

### HierarchicalMixtureOfExperts could not train at all
`_compute_leaf_weights` wrote each child's weight in place into one preallocated tensor. Autograd had saved that storage for the multiplication backward, so mutating it made every `loss.backward()` raise:

```
RuntimeError: one of the variables needed for gradient computation has been
modified by an inplace operation
```

Node weights are now held in a list, exactly the way `SoftDecisionTree._path_probabilities` already did it. The model trains; Wine test accuracy is on par with a comparable `MLPClassifier`.

### GALNetwork lost its output bias on every growth step
When a hidden unit was added, layer 0's weight and bias and layer 2's weight were carried over to the rebuilt network, but layer 2's **bias** was silently reset to a fresh init. The SGD optimizer was also reconstructed on every epoch instead of only when the architecture changed.

### Also in this PR
- `random_state` on `HierarchicalMixtureOfExperts` and `GALNetwork`
- `GALNetwork`, `WeightedKNN` and `NaiveBayesClassifier` exported at package level (#3)
- torch imports wrapped with an actionable `ImportError` naming `pip install torch` (#19)
- Tests: 21 -> 42. 11 for HMoE (tree shapes, single-class target, extreme dropout, dropout active in train mode only, MLP comparison, pipeline), 5 for GAL, 3 for the import guard, plus `depth=1` and `GridSearchCV` cases for `SoftDecisionTree` (#12)

Note on the dropout claim in #2: gating dropout barely moves the train/test gap, because it applies to gate activations only and not to the experts. The test is written as a regression guard, not as a proof, and the underlying gap is tracked separately.

Closes #2
Closes #3
Closes #12
Closes #19