### PR TITLE
Train GALNetwork on mini-batches so it actually learns

### DIFF
--- a/neural_trees/classical/multilayer_perceptron.py
+++ b/neural_trees/classical/multilayer_perceptron.py
@@ -33,6 +33,8 @@ from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 from sklearn.utils.multiclass import check_classification_targets
 
 from neural_trees._validation import check_predict_input
+from torch.utils.data import DataLoader, TensorDataset
+
 from typing import List, Optional
 
 
@@ -58,6 +60,12 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
     learning_rate : float, default=0.01
     check_interval : int, default=5
         How often (in epochs) to check growth/pruning conditions.
+    batch_size : int, default=32
+        Mini-batch size. Training used to take a single full-batch step per
+        epoch, which left the network barely moved from its initialization when
+        the growth criterion was evaluated.
+    momentum : float, default=0.9
+        Momentum for the SGD optimizer.
     device : str, default="cpu"
     verbose : bool, default=False
     random_state : int or None, default=None
@@ -79,6 +87,8 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         max_epochs: int = 100,
         learning_rate: float = 0.01,
         check_interval: int = 5,
+        batch_size: int = 32,
+        momentum: float = 0.9,
         device: str = "cpu",
         verbose: bool = False,
         random_state: Optional[int] = None,
@@ -90,9 +100,15 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         self.max_epochs = max_epochs
         self.learning_rate = learning_rate
         self.check_interval = check_interval
+        self.batch_size = batch_size
+        self.momentum = momentum
         self.device = device
         self.verbose = verbose
         self.random_state = random_state
+
+    def _make_optimizer(self, model: nn.Sequential) -> "torch.optim.Optimizer":
+        """A fresh optimizer, needed whenever growth or pruning rebuilds the network."""
+        return torch.optim.SGD(model.parameters(), lr=self.learning_rate, momentum=self.momentum)
 
     def _build_model(self, n_features: int, n_hidden: int, n_classes: int) -> nn.Sequential:
         return nn.Sequential(
@@ -120,18 +136,33 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         model = self._build_model(self.n_features_in_, n_hidden, n_classes).to(device)
         self.architecture_history_: List[dict] = []
 
-        optimizer = torch.optim.SGD(model.parameters(), lr=self.learning_rate)
+        optimizer = self._make_optimizer(model)
+
+        generator = None
+        if self.random_state is not None:
+            generator = torch.Generator()
+            generator.manual_seed(self.random_state)
+        loader = DataLoader(
+            TensorDataset(X_t, y_t),
+            batch_size=min(self.batch_size, len(X_t)),
+            shuffle=True,
+            generator=generator,
+        )
 
         for epoch in range(self.max_epochs):
             model.train()
-            optimizer.zero_grad()
-            logits = model(X_t)
-            loss = F.cross_entropy(logits, y_t)
-            loss.backward()
-            optimizer.step()
+            for X_batch, y_batch in loader:
+                optimizer.zero_grad()
+                loss = F.cross_entropy(model(X_batch), y_batch)
+                loss.backward()
+                optimizer.step()
 
-            acc = (logits.argmax(1) == y_t).float().mean().item()
-            error = 1.0 - acc
+            # The growth and pruning criteria have to see the network as it
+            # stands at the end of the epoch, not the logits from one stale
+            # mini-batch.
+            model.eval()
+            with torch.no_grad():
+                error = 1.0 - (model(X_t).argmax(1) == y_t).float().mean().item()
             self.architecture_history_.append(
                 {"epoch": epoch + 1, "n_hidden": n_hidden, "error": error}
             )
@@ -157,7 +188,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
                     model[2].weight.data = W2
                     model[2].bias.data = b2
 
-                    optimizer = torch.optim.SGD(model.parameters(), lr=self.learning_rate)
+                    optimizer = self._make_optimizer(model)
 
                     if self.verbose:
                         print(f"Epoch {epoch+1}: Pruned to {n_hidden} hidden units")
@@ -182,7 +213,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
                     model[2].weight.data = W2_new
                     model[2].bias.data = b2_old
 
-                    optimizer = torch.optim.SGD(model.parameters(), lr=self.learning_rate)
+                    optimizer = self._make_optimizer(model)
 
                     if self.verbose:
                         print(f"Epoch {epoch+1}: Grew to {n_hidden} hidden units")

--- a/tests/test_gal_network.py
+++ b/tests/test_gal_network.py
@@ -30,6 +30,37 @@ def test_fit_predict_shapes(iris_split):
     np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-5)
 
 
+def test_learns_a_separable_problem(iris_split):
+    """
+    Regression test for the training loop. GAL used to take exactly one
+    full-batch SGD step per epoch, so growth and pruning decisions were made on
+    a network that had barely moved from its initialization. On three well
+    separated blobs it scored 0.333, which is chance for three classes.
+    """
+    from sklearn.datasets import make_blobs
+
+    X, y = make_blobs(n_samples=300, centers=3, cluster_std=0.1, random_state=0)
+    gal = GALNetwork(max_epochs=100, random_state=0).fit(X, y)
+
+    assert gal.score(X, y) > 0.9
+
+
+def test_beats_the_majority_baseline_on_iris(iris_split):
+    X_train, X_test, y_train, y_test = iris_split
+    gal = GALNetwork(max_epochs=100, random_state=0).fit(X_train, y_train)
+
+    majority = np.bincount(y_test).max() / len(y_test)
+    assert gal.score(X_test, y_test) > majority
+
+
+def test_error_decreases_over_training(iris_split):
+    X_train, _, y_train, _ = iris_split
+    gal = GALNetwork(max_epochs=100, random_state=0).fit(X_train, y_train)
+
+    history = [h["error"] for h in gal.architecture_history_]
+    assert history[-1] < history[0]
+
+
 def test_architecture_grows_and_is_recorded(iris_split):
     X_train, _, y_train, _ = iris_split
     gal = GALNetwork(initial_hidden=2, max_hidden=8, max_epochs=60, random_state=0)


### PR DESCRIPTION
`GALNetwork` was not learning anything. On three well separated blobs it scored **0.333**, chance for three classes, and it was no better on the real datasets.

`fit` took exactly **one** full-batch SGD step per epoch, so `max_epochs=100` meant 100 gradient steps in total at `lr=0.01`. Growth and pruning decisions were then made on a network that had barely moved from its initialization, which is the part that matters for GAL specifically: the whole algorithm is a feedback loop between training progress and architecture.

### Changes

- Training iterates mini-batches (new `batch_size` parameter, default 32) instead of taking one full-batch step
- `momentum` on the SGD optimizer, default 0.9
- The error that drives the growth criterion is measured on the full training set at the end of each epoch in eval mode, rather than read off one stale mini-batch's logits
- Growth and pruning semantics from Alpaydin (1994) are untouched; this is the optimizer loop only

### Measured

| | before | after |
|---|:---:|:---:|
| blobs, train accuracy | 0.333 | **1.000** |
| Iris, 5-fold | 0.333 | **0.893** |
| Wine, 5-fold | 0.518 | **0.983** |
| Breast Cancer, 5-fold | 0.627 | **0.974** |

`check_estimator` goes from 52/55 to 54/55: `check_classifiers_train` now passes. The one remaining failure is `check_methods_sample_order_invariance`, the float32 tolerance issue tracked in #39.

Three regression tests added, including the blobs case that fails against the old code.

Closes #38