### PR TITLE
Harden the classical estimators, add omnivariate predict_proba

### DIFF
--- a/neural_trees/classical/k_nearest_neighbors.py
+++ b/neural_trees/classical/k_nearest_neighbors.py
@@ -64,21 +64,44 @@ class WeightedKNN(ClassifierMixin, BaseEstimator):
         raise ValueError(f"Unknown metric: {self.metric}")
 
     def _condense(self, X: np.ndarray, y: np.ndarray):
-        """Condensed Nearest Neighbor: keep minimal prototypical subset."""
-        store_X = [X[0]]
-        store_y = [y[0]]
+        """
+        Condensed Nearest Neighbor (Hart, 1968).
 
-        for i in range(1, len(X)):
-            xi, yi = X[i], y[i]
-            dists = np.array([np.linalg.norm(xi - s) for s in store_X])
-            nearest_idx = np.argmin(dists)
-            if store_y[nearest_idx] != yi:
-                store_X.append(xi)
-                store_y.append(yi)
+        Sweep the training set repeatedly, moving into the store any sample the
+        current store misclassifies under the 1-nearest-neighbor rule, until a
+        full sweep adds nothing. The result is *consistent*: the store
+        classifies every training sample correctly.
 
-        return np.array(store_X), np.array(store_y)
+        A single sweep, which is what this used to do, stops before that
+        property holds, because samples seen early are judged against a store
+        that later grows.
+        """
+        store_idx = [0]
+        remaining = list(range(1, len(X)))
+
+        changed = True
+        while changed:
+            changed = False
+            still_remaining = []
+            for i in remaining:
+                dists = self._distance(X[i][None, :], X[store_idx])[0]
+                if y[store_idx[int(np.argmin(dists))]] != y[i]:
+                    store_idx.append(i)
+                    changed = True
+                else:
+                    still_remaining.append(i)
+            remaining = still_remaining
+
+        return X[store_idx], y[store_idx]
 
     def fit(self, X, y):
+        if self.metric not in ("euclidean", "manhattan"):
+            raise ValueError(
+                f"metric must be 'euclidean' or 'manhattan', got {self.metric!r}"
+            )
+        if isinstance(self.k, bool) or not isinstance(self.k, int) or self.k < 1:
+            raise ValueError(f"k must be a positive integer, got {self.k!r}")
+
         X, y = check_X_y(X, y)
         check_classification_targets(y)
         self.le_ = LabelEncoder()
@@ -106,8 +129,13 @@ class WeightedKNN(ClassifierMixin, BaseEstimator):
             nn_idx = np.argsort(row)[:k]
             nn_dists = row[nn_idx]
 
-            if self.weight_power == 0 or nn_dists[0] == 0:
+            if self.weight_power == 0:
                 weights = np.ones(k)
+            elif nn_dists[0] == 0:
+                # Exact matches carry the whole vote. Falling back to uniform
+                # weights here, as this used to, let k - 1 unrelated neighbors
+                # outvote a sample identical to the query.
+                weights = (nn_dists == 0).astype(float)
             else:
                 weights = 1.0 / (nn_dists ** self.weight_power + 1e-10)
 

--- a/neural_trees/classical/naive_bayes.py
+++ b/neural_trees/classical/naive_bayes.py
@@ -44,6 +44,12 @@ class NaiveBayesClassifier(ClassifierMixin, BaseEstimator):
         self.var_smoothing = var_smoothing
 
     def fit(self, X, y):
+        if self.likelihood not in ("gaussian", "bernoulli", "multinomial"):
+            raise ValueError(
+                "likelihood must be 'gaussian', 'bernoulli' or 'multinomial', got "
+                f"{self.likelihood!r}"
+            )
+
         X, y = check_X_y(X, y)
         check_classification_targets(y)
         self.le_ = LabelEncoder()

--- a/neural_trees/decision_trees/omnivariate_tree.py
+++ b/neural_trees/decision_trees/omnivariate_tree.py
@@ -37,8 +37,11 @@ from typing import Optional, Dict, Any
 class _OmnivariateNode:
     """A single node in an omnivariate decision tree."""
 
-    def __init__(self, depth: int, max_depth: int, min_samples_split: int, cv_folds: int):
+    def __init__(self, depth: int, max_depth: int, min_samples_split: int, cv_folds: int,
+                 n_classes: int = 0):
         self.depth = depth
+        self.n_classes = n_classes
+        self.distribution: Optional[np.ndarray] = None
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
         self.cv_folds = cv_folds
@@ -48,6 +51,13 @@ class _OmnivariateNode:
         self.leaf_class = None
         self.left: Optional["_OmnivariateNode"] = None
         self.right: Optional["_OmnivariateNode"] = None
+
+    def _make_leaf(self, y: np.ndarray) -> "_OmnivariateNode":
+        counts = np.bincount(y, minlength=self.n_classes).astype(float)
+        self.is_leaf = True
+        self.leaf_class = int(counts.argmax())
+        self.distribution = counts / counts.sum() if counts.sum() else counts
+        return self
 
     def _two_group_labels(self, X: np.ndarray, y: np.ndarray):
         """
@@ -99,15 +109,11 @@ class _OmnivariateNode:
             or len(X) < self.min_samples_split
             or len(np.unique(y)) == 1
         ):
-            self.is_leaf = True
-            self.leaf_class = np.bincount(y).argmax()
-            return self
+            return self._make_leaf(y)
 
         y_bin = self._two_group_labels(X, y)
         if y_bin is None:
-            self.is_leaf = True
-            self.leaf_class = np.bincount(y).argmax()
-            return self
+            return self._make_leaf(y)
 
         self.split_type, self.classifier = self._select_best_splitter(X, y_bin)
         self.classifier.fit(X, y_bin)
@@ -118,24 +124,28 @@ class _OmnivariateNode:
         mask_left = ~mask_right
 
         if mask_right.sum() == 0 or mask_left.sum() == 0:
-            self.is_leaf = True
-            self.leaf_class = np.bincount(y).argmax()
-            return self
+            return self._make_leaf(y)
 
         self.left = _OmnivariateNode(
-            self.depth + 1, self.max_depth, self.min_samples_split, self.cv_folds
+            self.depth + 1, self.max_depth, self.min_samples_split, self.cv_folds, self.n_classes
         ).fit(X[mask_left], y[mask_left])
         self.right = _OmnivariateNode(
-            self.depth + 1, self.max_depth, self.min_samples_split, self.cv_folds
+            self.depth + 1, self.max_depth, self.min_samples_split, self.cv_folds, self.n_classes
         ).fit(X[mask_right], y[mask_right])
         return self
 
-    def predict_one(self, x: np.ndarray) -> int:
+    def _leaf_for(self, x: np.ndarray) -> "_OmnivariateNode":
         node = self
         while not node.is_leaf:
             goes_right = node.classifier.predict(x.reshape(1, -1))[0] == 1
             node = node.right if goes_right else node.left
-        return node.leaf_class
+        return node
+
+    def predict_one(self, x: np.ndarray) -> int:
+        return self._leaf_for(x).leaf_class
+
+    def predict_proba_one(self, x: np.ndarray) -> np.ndarray:
+        return self._leaf_for(x).distribution
 
 
 class OmnivariateDecisionTree(ClassifierMixin, BaseEstimator):
@@ -194,8 +204,27 @@ class OmnivariateDecisionTree(ClassifierMixin, BaseEstimator):
             max_depth=self.max_depth,
             min_samples_split=self.min_samples_split,
             cv_folds=self.cv_folds,
+            n_classes=len(self.classes_),
         ).fit(X, y_enc)
         return self
+
+    def predict_proba(self, X):
+        """
+        Predict class probabilities from the reached leaf's class distribution.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Class probabilities in the order of `self.classes_`, each row
+            summing to 1.
+        """
+        check_is_fitted(self)
+        X = check_predict_input(self, X)
+        return np.vstack([self.root_.predict_proba_one(x) for x in X])
 
     def predict(self, X):
         check_is_fitted(self)

--- a/tests/test_naive_bayes.py
+++ b/tests/test_naive_bayes.py
@@ -1,0 +1,88 @@
+"""Tests for the Naive Bayes classifier and its three likelihoods."""
+import numpy as np
+import pytest
+from sklearn.datasets import load_digits, load_iris
+from sklearn.model_selection import train_test_split
+
+from neural_trees import NaiveBayesClassifier
+
+
+@pytest.fixture(scope="module")
+def iris_split():
+    X, y = load_iris(return_X_y=True)
+    return train_test_split(X, y, test_size=0.3, stratify=y, random_state=0)
+
+
+def test_gaussian_fit_predict(iris_split):
+    X_train, X_test, y_train, y_test = iris_split
+    nb = NaiveBayesClassifier().fit(X_train, y_train)
+
+    preds = nb.predict(X_test)
+    assert preds.shape == y_test.shape
+    assert set(preds).issubset(set(np.unique(y_train)))
+    assert nb.score(X_test, y_test) > 0.85
+
+
+def test_bernoulli_likelihood_on_binarized_features(iris_split):
+    X_train, X_test, y_train, y_test = iris_split
+    threshold = X_train.mean(axis=0)
+    nb = NaiveBayesClassifier(likelihood="bernoulli").fit(
+        (X_train > threshold).astype(float), y_train
+    )
+
+    score = nb.score((X_test > threshold).astype(float), y_test)
+    majority = np.bincount(y_test).max() / len(y_test)
+    assert score > majority
+
+
+def test_multinomial_likelihood_on_count_features():
+    X, y = load_digits(return_X_y=True)  # pixel intensities are counts
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.3, stratify=y, random_state=0
+    )
+    nb = NaiveBayesClassifier(likelihood="multinomial").fit(X_train, y_train)
+    assert nb.score(X_test, y_test) > 0.8
+
+
+@pytest.mark.parametrize("likelihood", ["gaussian", "bernoulli", "multinomial"])
+def test_every_likelihood_returns_a_proper_distribution(likelihood, iris_split):
+    X_train, X_test, y_train, _ = iris_split
+    if likelihood != "gaussian":
+        threshold = X_train.mean(axis=0)
+        X_train = (X_train > threshold).astype(float)
+        X_test = (X_test > threshold).astype(float)
+
+    nb = NaiveBayesClassifier(likelihood=likelihood).fit(X_train, y_train)
+    proba = nb.predict_proba(X_test)
+    log_proba = nb.predict_log_proba(X_test)
+
+    assert proba.shape == (len(X_test), 3)
+    assert (proba >= 0).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-9)
+    np.testing.assert_allclose(np.exp(log_proba), proba, atol=1e-12)
+
+
+def test_class_priors_match_label_frequencies():
+    X, y = load_iris(return_X_y=True)
+    y = np.where(y == 2, 1, y)  # make the classes deliberately unbalanced
+    nb = NaiveBayesClassifier().fit(X, y)
+
+    expected = np.log(np.bincount(y) / len(y))
+    np.testing.assert_allclose(nb.class_log_prior_, expected)
+
+
+def test_zero_variance_feature_does_not_produce_nan():
+    """A feature constant within a class would divide by zero without smoothing."""
+    X, y = load_iris(return_X_y=True)
+    X = np.column_stack([X, np.ones(len(X))])  # constant column
+
+    nb = NaiveBayesClassifier().fit(X, y)
+    proba = nb.predict_proba(X)
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-9)
+
+
+def test_unknown_likelihood_is_rejected_at_fit():
+    X, y = load_iris(return_X_y=True)
+    with pytest.raises(ValueError, match="likelihood must be"):
+        NaiveBayesClassifier(likelihood="poisson").fit(X, y)

--- a/tests/test_omnivariate_tree.py
+++ b/tests/test_omnivariate_tree.py
@@ -68,3 +68,34 @@ def test_works_in_a_pipeline():
     ])
     pipe.fit(X, y)
     assert pipe.score(X, y) > 0.7
+
+
+def test_predict_proba_is_a_distribution(wine_split):
+    """
+    This was the one estimator in the library without predict_proba, so it
+    could not be used for ROC AUC, calibration or soft voting.
+    """
+    X_train, X_test, y_train, _ = wine_split
+    odt = OmnivariateDecisionTree(max_depth=3).fit(X_train, y_train)
+
+    proba = odt.predict_proba(X_test)
+    assert proba.shape == (len(X_test), 3)
+    assert (proba >= 0).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-9)
+
+
+def test_predict_proba_agrees_with_predict(wine_split):
+    X_train, X_test, y_train, _ = wine_split
+    odt = OmnivariateDecisionTree(max_depth=3).fit(X_train, y_train)
+
+    from_proba = odt.classes_[odt.predict_proba(X_test).argmax(axis=1)]
+    assert np.array_equal(from_proba, odt.predict(X_test))
+
+
+def test_works_with_roc_auc(wine_split):
+    from sklearn.metrics import roc_auc_score
+
+    X_train, X_test, y_train, y_test = wine_split
+    odt = OmnivariateDecisionTree(max_depth=3).fit(X_train, y_train)
+    auc = roc_auc_score(y_test, odt.predict_proba(X_test), multi_class="ovr")
+    assert 0.0 <= auc <= 1.0

--- a/tests/test_weighted_knn.py
+++ b/tests/test_weighted_knn.py
@@ -1,0 +1,112 @@
+"""Tests for distance-weighted KNN and its condensed-prototype mode."""
+import numpy as np
+import pytest
+from sklearn.datasets import load_iris
+from sklearn.model_selection import cross_val_score, train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import WeightedKNN
+
+
+@pytest.fixture(scope="module")
+def iris_split():
+    X, y = load_iris(return_X_y=True)
+    return train_test_split(X, y, test_size=0.3, stratify=y, random_state=0)
+
+
+def test_fit_predict_and_proba(iris_split):
+    X_train, X_test, y_train, y_test = iris_split
+    knn = WeightedKNN().fit(X_train, y_train)
+
+    preds = knn.predict(X_test)
+    assert preds.shape == y_test.shape
+    assert set(preds).issubset(set(np.unique(y_train)))
+    assert knn.score(X_test, y_test) > 0.9
+
+    proba = knn.predict_proba(X_test)
+    assert proba.shape == (len(X_test), 3)
+    assert (proba >= 0).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-9)
+
+
+@pytest.mark.parametrize("metric", ["euclidean", "manhattan"])
+def test_both_metrics_work(iris_split, metric):
+    X_train, X_test, y_train, y_test = iris_split
+    knn = WeightedKNN(metric=metric).fit(X_train, y_train)
+    assert knn.score(X_test, y_test) > 0.9
+
+
+def test_manhattan_and_euclidean_differ_somewhere():
+    """Otherwise the metric parameter would be decorative."""
+    rng = np.random.RandomState(0)
+    X = rng.randn(120, 8)
+    y = (X[:, 0] + 0.5 * X[:, 3] > 0).astype(int)
+    queries = rng.randn(40, 8)  # not in the training set, so no exact matches
+
+    euclid = WeightedKNN(k=3, metric="euclidean").fit(X, y).predict_proba(queries)
+    manhattan = WeightedKNN(k=3, metric="manhattan").fit(X, y).predict_proba(queries)
+    assert not np.allclose(euclid, manhattan)
+
+
+def test_uniform_weights_when_power_is_zero():
+    X = np.array([[0.0], [1.0], [10.0], [11.0]])
+    y = np.array([0, 0, 1, 1])
+    query = np.array([[5.4]])
+
+    weighted = WeightedKNN(k=4, weight_power=2.0).fit(X, y).predict_proba(query)
+    uniform = WeightedKNN(k=4, weight_power=0.0).fit(X, y).predict_proba(query)
+
+    np.testing.assert_allclose(uniform, [[0.5, 0.5]])
+    assert not np.allclose(weighted, uniform)
+
+
+def test_exact_match_carries_the_vote():
+    """
+    A query identical to a training sample must take that sample's label.
+    Uniform fallback on a zero distance let k - 1 unrelated neighbors outvote it.
+    """
+    X = np.array([[0.0], [1.0], [1.1], [1.2], [1.3]])
+    y = np.array([0, 1, 1, 1, 1])
+
+    proba = WeightedKNN(k=5, weight_power=2.0).fit(X, y).predict_proba(np.array([[0.0]]))
+    np.testing.assert_allclose(proba, [[1.0, 0.0]])
+
+
+def test_condensed_store_is_consistent_and_smaller():
+    """
+    Hart's condensing keeps sweeping until the store classifies every training
+    sample correctly. A single sweep, which is what this used to do, stops
+    short of that.
+    """
+    X, y = load_iris(return_X_y=True)
+    knn = WeightedKNN(condense=True).fit(X, y)
+
+    assert len(knn.X_train_) < len(X)
+    distances = knn._distance(X, knn.X_train_)
+    nearest_label = knn.y_train_[distances.argmin(axis=1)]
+    assert np.array_equal(nearest_label, knn.le_.transform(y))
+
+
+def test_condensing_keeps_accuracy_close_to_the_full_set():
+    X, y = load_iris(return_X_y=True)
+    full = Pipeline([("s", StandardScaler()), ("k", WeightedKNN())])
+    condensed = Pipeline([("s", StandardScaler()), ("k", WeightedKNN(condense=True))])
+
+    full_score = cross_val_score(full, X, y, cv=5).mean()
+    condensed_score = cross_val_score(condensed, X, y, cv=5).mean()
+    assert condensed_score > full_score - 0.1
+
+
+@pytest.mark.parametrize("bad", [{"metric": "cosine"}, {"k": 0}, {"k": -1}, {"k": 2.5}])
+def test_invalid_parameters_are_rejected(bad):
+    X, y = load_iris(return_X_y=True)
+    with pytest.raises(ValueError):
+        WeightedKNN(**bad).fit(X, y)
+
+
+def test_k_larger_than_training_set_is_clamped():
+    X = np.array([[0.0], [1.0], [2.0]])
+    y = np.array([0, 1, 1])
+    proba = WeightedKNN(k=50).fit(X, y).predict_proba(np.array([[1.5]]))
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0)


### PR DESCRIPTION
Coverage was 75% for `k_nearest_neighbors.py` and 80% for `naive_bayes.py`. The uncovered lines were not edge cases: condensed nearest neighbour, the manhattan metric, and the bernoulli and multinomial likelihoods had **no tests at all**. Writing them surfaced two defects.

### Condensed nearest neighbour was inconsistent

`_condense` made a single sweep, so a sample seen early was judged against a store that later grew, and the result did not classify the training set correctly. Hart's algorithm sweeps until a full pass adds nothing. It also always used `np.linalg.norm`, ignoring `metric`.

5-fold accuracy with `condense=True`:

| | before | after |
|---|:---:|:---:|
| Iris | 0.747 | **0.933** |
| Wine | 0.792 | **0.933** |
| Breast Cancer | 0.935 | **0.951** |

On Iris the store is now 24 of 150 samples and is verified consistent in a test.

### Exact matches were diluted

`if self.weight_power == 0 or nn_dists[0] == 0: weights = np.ones(k)` gave a uniform vote whenever the nearest neighbour was at distance zero, so `k - 1` unrelated neighbours could outvote a training sample identical to the query. Zero-distance neighbours now carry the whole vote. Held-out accuracy is unchanged (0.960 / 0.972 / 0.965), as expected, since test points are not in the training set.

### OmnivariateDecisionTree now has predict_proba

It was the only estimator in the library without it, which ruled out ROC AUC, calibration and soft voting. Leaves keep the full class distribution rather than just the majority label.

### Also

- `metric`, `k` and `likelihood` are validated in `fit` instead of failing later inside a distance or likelihood computation
- 107 -> 132 tests; `OmnivariateDecisionTree`, `WeightedKNN` and `NaiveBayesClassifier` each pass `check_estimator` 55/55

Closes #32
Closes #33