### PR TITLE
Test the Python versions we claim to support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Decision boundary learning with Soft Decision Trees on a toy dataset.
 
 [![PyPI](https://img.shields.io/pypi/v/neural-trees)](https://pypi.org/project/neural-trees/)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/neural-trees?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/neural-trees)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Tests](https://github.com/cgrtml/neural-trees/actions/workflows/tests.yml/badge.svg)](https://github.com/cgrtml/neural-trees/actions)
 [![GitHub Stars](https://img.shields.io/github/stars/cgrtml/neural-trees?style=social)](https://github.com/cgrtml/neural-trees/stargazers)
@@ -278,6 +278,7 @@ Thanks to everyone who has improved this library.
 |---|---|
 | [@snoopuppy582](https://github.com/snoopuppy582) | Symmetric McNemar disagreement test (#20), development requirements (#23), depth validation (#22), reproducibility test (#24) |
 | [@aribaskagan](https://github.com/aribaskagan) | Fixed the coverage target in CI, which had been measuring a module that no longer exists (#25) |
+| [@yunaremaia](https://github.com/yunaremaia) | Migrated packaging to `pyproject.toml` and wired ruff into CI (#46) |
 <!-- CONTRIBUTORS-END -->
 
 The list began with the GitHub Sprint segment of the WSU Data and Analytics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 description = "Soft decision trees, mixture of experts, and statistical model comparison tests for Python. Scikit-learn compatible, PyTorch backend."
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Cagri Temel", email = "cagritemel34@gmail.com" },
 ]
@@ -36,10 +36,11 @@ classifiers = [
     "Intended Audience :: Education",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
@@ -69,7 +70,7 @@ include = ["neural_trees*"]
 exclude = ["tests*", "notebooks*", "examples*", "benchmarks*"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 exclude = ["notebooks/"]
 
 [tool.ruff.lint]


### PR DESCRIPTION
`requires-python` said `>=3.8` while the CI matrix ran 3.9 to 3.11. So the oldest version we advertised was never tested, and the two newest releases were not covered at all.

- Floor raised to **3.9**. Python 3.8 reached end of life in October 2024, and nothing here has ever run against it.
- Matrix extended to **3.12 and 3.13**.
- Classifiers, the README badge and ruff's `target-version` follow.

Held back until #46 landed, since both touched the same two files.

Also adds @yunaremaia to the contributors table.