### PR TITLE
Let GAL decide its architecture on held-out evidence

### DIFF
--- a/neural_trees/classical/multilayer_perceptron.py
+++ b/neural_trees/classical/multilayer_perceptron.py
@@ -30,6 +30,7 @@ except ImportError as exc:  # pragma: no cover - exercised only without torch
 from typing import List, Optional
 
 from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
@@ -52,14 +53,53 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
     max_hidden : int, default=50
         Maximum hidden units before stopping growth.
     grow_threshold : float, default=0.1
-        Error threshold above which a new unit is added.
+        Training-error threshold above which a new unit is added. Only used by
+        the ``"error_threshold"`` policy.
     prune_threshold : float, default=1e-4
-        Activation variance below which a unit is pruned.
+        Activation variance below which a unit is pruned. Only used by the
+        ``"error_threshold"`` policy.
     max_epochs : int, default=100
         Maximum training epochs.
     learning_rate : float, default=0.01
     check_interval : int, default=5
-        How often (in epochs) to check growth/pruning conditions.
+        How often (in epochs) to reconsider the architecture.
+    growth_policy : {"error_threshold", "validation"}, default="error_threshold"
+        How growth and pruning decide.
+
+        - ``"validation"`` holds out `validation_fraction` of the training data
+          and changes the architecture only when validation loss has stopped
+          improving. A unit is pruned when removing it does not hurt validation
+          loss, and one is grown otherwise. Training stops after `patience`
+          consecutive changes that fail to improve validation loss, and the
+          parameters of the best epoch are restored.
+        - ``"error_threshold"`` is the earlier behaviour: prune any unit whose
+          activation variance falls below `prune_threshold`, otherwise grow
+          whenever *training* error exceeds `grow_threshold`. That rule grows
+          the network until it fits the training set, with nothing held out to
+          say whether the extra capacity helped.
+
+        Falls back to ``"error_threshold"`` when the data is too small to hold
+        out a usable validation split; `growth_policy_` records what was used.
+
+        ``"validation"`` is not the default yet. It reaches far smaller networks
+        for the same accuracy where capacity is not the constraint (Breast
+        Cancer: 0.977 with 3.9 units against 0.975 with 2.0), but it under-grows
+        where capacity *is* the constraint (6 separable blobs: 0.620 with 4.1
+        units against 0.967 with 15.1). The cause is measured, not guessed: a
+        capacity-starved network keeps improving its validation loss slowly, so
+        "loss is still falling" never signals that more units are what is
+        missing. Deciding this properly needs a signal about what a new unit
+        would buy, which a randomly initialized unit cannot provide.
+    validation_fraction : float, default=0.2
+        Fraction held out under the ``"validation"`` policy.
+    tol : float, default=1e-2
+        Relative improvement in validation loss that counts as progress. A loss
+        still creeping down by a fraction of a percent per check is a network
+        that has stopped learning anything useful with the capacity it has, and
+        treating that as progress is what keeps it from ever growing.
+    patience : int, default=5
+        Consecutive architecture changes without a validation improvement
+        before training stops.
     batch_size : int, default=32
         Mini-batch size. Training used to take a single full-batch step per
         epoch, which left the network barely moved from its initialization when
@@ -87,6 +127,10 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         max_epochs: int = 100,
         learning_rate: float = 0.01,
         check_interval: int = 5,
+        growth_policy: str = "error_threshold",
+        validation_fraction: float = 0.2,
+        tol: float = 1e-2,
+        patience: int = 5,
         batch_size: int = 32,
         momentum: float = 0.9,
         device: str = "cpu",
@@ -100,6 +144,10 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         self.max_epochs = max_epochs
         self.learning_rate = learning_rate
         self.check_interval = check_interval
+        self.growth_policy = growth_policy
+        self.validation_fraction = validation_fraction
+        self.tol = tol
+        self.patience = patience
         self.batch_size = batch_size
         self.momentum = momentum
         self.device = device
@@ -188,6 +236,28 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         return model
 
     def fit(self, X, y):
+        """
+        Fit the network, growing and pruning hidden units as it trains.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+        y : array-like of shape (n_samples,)
+
+        Returns
+        -------
+        self
+        """
+        if self.growth_policy not in ("validation", "error_threshold"):
+            raise ValueError(
+                "growth_policy must be 'validation' or 'error_threshold', got "
+                f"{self.growth_policy!r}"
+            )
+        if not 0.0 < self.validation_fraction < 1.0:
+            raise ValueError(
+                f"validation_fraction must be in (0, 1), got {self.validation_fraction!r}"
+            )
+
         X, y = check_X_y(X, y)
         check_classification_targets(y)
         if self.random_state is not None:
@@ -199,13 +269,18 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         n_classes = len(self.classes_)
         device = torch.device(self.device)
 
-        X_t = torch.FloatTensor(X).to(device)
-        y_t = torch.LongTensor(y_enc).to(device)
+        X_fit, y_fit, X_val, y_val = self._split_for_validation(X, y_enc)
+        self.growth_policy_ = "validation" if X_val is not None else "error_threshold"
 
-        n_hidden = self.initial_hidden
-        model = self._build_model(self.n_features_in_, n_hidden, n_classes).to(device)
-        self.architecture_history_: List[dict] = []
+        X_t = torch.FloatTensor(X_fit).to(device)
+        y_t = torch.LongTensor(y_fit).to(device)
+        if X_val is not None:
+            X_val_t = torch.FloatTensor(X_val).to(device)
+            y_val_t = torch.LongTensor(y_val).to(device)
+        else:
+            X_val_t, y_val_t = X_t, y_t
 
+        model = self._build_model(self.n_features_in_, self.initial_hidden, n_classes).to(device)
         optimizer = self._make_optimizer(model)
 
         generator = None
@@ -219,6 +294,17 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
             generator=generator,
         )
 
+        self.architecture_history_: List[dict] = []
+        best_loss = np.inf
+        best_snapshot = self._snapshot(model)
+        # The architecture decision asks what the last stretch of training
+        # bought, so it compares against the previous checkpoint. best_loss is
+        # bookkeeping for restoring the best parameters at the end, and using it
+        # as the reference made the network prune itself at the very first
+        # check, before it had trained at all.
+        reference_loss = np.inf
+        changes_without_gain = 0
+
         for epoch in range(self.max_epochs):
             model.train()
             for X_batch, y_batch in loader:
@@ -227,70 +313,166 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
                 loss.backward()
                 optimizer.step()
 
-            # The growth and pruning criteria have to see the network as it
-            # stands at the end of the epoch, not the logits from one stale
-            # mini-batch.
-            model.eval()
-            with torch.no_grad():
-                error = 1.0 - (model(X_t).argmax(1) == y_t).float().mean().item()
-            self.architecture_history_.append(
-                {"epoch": epoch + 1, "n_hidden": n_hidden, "error": error}
+            # Architecture decisions look at the network as it stands at the end
+            # of the epoch, not at one stale mini-batch's logits.
+            train_loss, train_error = self._evaluate(model, X_t, y_t)
+            val_loss, val_error = (
+                self._evaluate(model, X_val_t, y_val_t)
+                if X_val is not None
+                else (train_loss, train_error)
             )
 
+            record = {
+                "epoch": epoch + 1,
+                "n_hidden": model[0].weight.shape[0],
+                "error": train_error,
+                "loss": train_loss,
+                "val_error": val_error,
+                "val_loss": val_loss,
+                "action": "train",
+            }
+
             if (epoch + 1) % self.check_interval == 0:
-                with torch.no_grad():
-                    hidden_acts = model[1](model[0](X_t))  # (N, n_hidden)
-                    act_var = hidden_acts.var(dim=0)  # (n_hidden,)
+                if self.growth_policy_ == "validation":
+                    model, optimizer, record, changes_without_gain = self._validation_step(
+                        model, optimizer, record, X_t, X_val_t, y_val_t,
+                        n_classes, device, val_loss, reference_loss, changes_without_gain,
+                    )
+                    if val_loss < best_loss:
+                        best_loss, best_snapshot = val_loss, self._snapshot(model)
 
-                # Prune low-variance units
-                keep_mask = act_var > self.prune_threshold
-                if keep_mask.sum() < n_hidden and keep_mask.sum() >= 1:
-                    keep_idx = keep_mask.nonzero(as_tuple=True)[0]
-                    W1 = model[0].weight.data[keep_idx]
-                    b1 = model[0].bias.data[keep_idx]
-                    W2 = model[2].weight.data[:, keep_idx]
-                    b2 = model[2].bias.data
+                    # After a change, the next check has to judge the new
+                    # architecture against its own starting point. Comparing it
+                    # to the pre-change loss punishes growth for the dip a fresh
+                    # random unit causes, which stopped the search after three
+                    # attempts before any added unit had time to become useful.
+                    reference_loss = (
+                        self._evaluate(model, X_val_t, y_val_t)[0]
+                        if record["action"] in ("grow", "prune")
+                        else val_loss
+                    )
+                    if changes_without_gain >= self.patience:
+                        if self.verbose:
+                            print(f"Epoch {epoch+1}: architecture search exhausted, stopping")
+                        self.architecture_history_.append(record)
+                        break
+                else:
+                    model, optimizer, record = self._threshold_step(
+                        model, optimizer, record, X_t, train_error, n_classes, device
+                    )
+                    if val_loss < best_loss:
+                        best_loss = val_loss
+                        best_snapshot = self._snapshot(model)
 
-                    n_hidden = len(keep_idx)
-                    model = self._build_model(self.n_features_in_, n_hidden, n_classes).to(device)
-                    model[0].weight.data = W1
-                    model[0].bias.data = b1
-                    model[2].weight.data = W2
-                    model[2].bias.data = b2
+            elif val_loss < best_loss:
+                best_loss = val_loss
+                best_snapshot = self._snapshot(model)
 
-                    optimizer = self._make_optimizer(model)
+            self.architecture_history_.append(record)
 
-                    if self.verbose:
-                        print(f"Epoch {epoch+1}: Pruned to {n_hidden} hidden units")
+            if self.verbose and (epoch + 1) % self.check_interval == 0:
+                print(
+                    f"Epoch {epoch+1}/{self.max_epochs}  units={record['n_hidden']}  "
+                    f"train_err={train_error:.4f}  val_loss={val_loss:.4f}  {record['action']}"
+                )
 
-                # Grow if error is high
-                elif error > self.grow_threshold and n_hidden < self.max_hidden:
-                    b2_old = model[2].bias.data.clone()
-                    W1_new = torch.cat([
-                        model[0].weight.data,
-                        torch.randn(1, self.n_features_in_, device=device) * 0.1
-                    ], dim=0)
-                    b1_new = torch.cat([model[0].bias.data, torch.zeros(1, device=device)])
-                    W2_new = torch.cat([
-                        model[2].weight.data,
-                        torch.randn(n_classes, 1, device=device) * 0.1
-                    ], dim=1)
-
-                    n_hidden += 1
-                    model = self._build_model(self.n_features_in_, n_hidden, n_classes).to(device)
-                    model[0].weight.data = W1_new
-                    model[0].bias.data = b1_new
-                    model[2].weight.data = W2_new
-                    model[2].bias.data = b2_old
-
-                    optimizer = self._make_optimizer(model)
-
-                    if self.verbose:
-                        print(f"Epoch {epoch+1}: Grew to {n_hidden} hidden units")
-
-        self.model_ = model
-        self.n_hidden_final_ = n_hidden
+        self.model_ = self._restore(best_snapshot, n_classes, device)
+        self.n_hidden_final_ = best_snapshot["n_hidden"]
+        self.best_val_loss_ = float(best_loss)
+        self.n_iter_ = len(self.architecture_history_)
         return self
+
+    def _split_for_validation(self, X: np.ndarray, y_enc: np.ndarray):
+        """
+        Hold out a validation split, or report that the data cannot support one.
+
+        check_estimator and small real datasets both hand over sets where a
+        stratified split would leave a class unrepresented, so the policy falls
+        back rather than failing.
+        """
+        if self.growth_policy != "validation":
+            return X, y_enc, None, None
+
+        counts = np.bincount(y_enc)
+        n_classes = len(counts)
+        n_val = int(round(len(X) * self.validation_fraction))
+        if counts.min() < 2 or n_val < n_classes or len(X) - n_val < n_classes:
+            return X, y_enc, None, None
+
+        X_fit, X_val, y_fit, y_val = train_test_split(
+            X,
+            y_enc,
+            test_size=self.validation_fraction,
+            random_state=self.random_state,
+            stratify=y_enc,
+        )
+        return X_fit, y_fit, X_val, y_val
+
+    def _validation_step(
+        self, model, optimizer, record, X_t, X_val_t, y_val_t, n_classes, device,
+        val_loss, reference_loss, changes_without_gain,
+    ):
+        """
+        Change the architecture only when validation loss says the current one
+        has stopped paying off.
+
+        While validation loss is still falling, the network is learning and its
+        size is not the constraint. Once it stalls, try removing the least
+        useful unit first: a smaller network that validates just as well is
+        strictly better. Only if that fails is a unit added.
+        """
+        if val_loss < reference_loss * (1.0 - self.tol):
+            record["action"] = "keep"
+            return model, optimizer, record, 0
+
+        n_hidden = model[0].weight.shape[0]
+
+        if n_hidden > 1:
+            contributions = self._contributions(model, X_t)
+            victim = int(contributions.argmin())
+            keep_idx = [i for i in range(n_hidden) if i != victim]
+            candidate = self._rebuild_with_units(model, keep_idx, n_classes, device)
+            candidate_loss, _ = self._evaluate(candidate, X_val_t, y_val_t)
+            # Removing a unit is worth it only if validation loss does not get
+            # worse than it already is: a smaller network that validates the
+            # same is strictly the better model.
+            if candidate_loss <= val_loss + 1e-6:
+                record["action"] = "prune"
+                record["n_hidden"] = n_hidden - 1
+                return (
+                    candidate, self._make_optimizer(candidate), record,
+                    changes_without_gain + 1,
+                )
+
+        if n_hidden < self.max_hidden:
+            grown = self._grown(model, n_classes, device)
+            record["action"] = "grow"
+            record["n_hidden"] = n_hidden + 1
+            return grown, self._make_optimizer(grown), record, changes_without_gain + 1
+
+        record["action"] = "capped"
+        return model, optimizer, record, changes_without_gain + 1
+
+    def _threshold_step(self, model, optimizer, record, X_t, train_error, n_classes, device):
+        """The pre-0.4 rule: prune on activation variance, grow on training error."""
+        n_hidden = model[0].weight.shape[0]
+        activations = self._hidden_activations(model, X_t)
+        keep_mask = activations.var(dim=0) > self.prune_threshold
+
+        if 1 <= int(keep_mask.sum()) < n_hidden:
+            keep_idx = keep_mask.nonzero(as_tuple=True)[0].tolist()
+            model = self._rebuild_with_units(model, keep_idx, n_classes, device)
+            record["action"] = "prune"
+            record["n_hidden"] = len(keep_idx)
+            return model, self._make_optimizer(model), record
+
+        if train_error > self.grow_threshold and n_hidden < self.max_hidden:
+            model = self._grown(model, n_classes, device)
+            record["action"] = "grow"
+            record["n_hidden"] = n_hidden + 1
+            return model, self._make_optimizer(model), record
+
+        return model, optimizer, record
 
     def predict_proba(self, X):
         check_is_fitted(self)

--- a/neural_trees/classical/multilayer_perceptron.py
+++ b/neural_trees/classical/multilayer_perceptron.py
@@ -117,6 +117,76 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
             nn.Linear(n_hidden, n_classes),
         )
 
+    @staticmethod
+    def _hidden_activations(model: nn.Sequential, X_t: "torch.Tensor") -> "torch.Tensor":
+        with torch.no_grad():
+            return model[1](model[0](X_t))
+
+    def _contributions(self, model: nn.Sequential, X_t: "torch.Tensor") -> "torch.Tensor":
+        """
+        How much each hidden unit actually moves the output.
+
+        Activation variance alone, which is what pruning used to look at, says
+        nothing about whether the unit matters: a nearly constant unit with a
+        large outgoing weight still shifts every logit. Weighting the spread of
+        a unit's activation by the size of its outgoing weights measures the
+        thing pruning is supposed to care about.
+        """
+        activations = self._hidden_activations(model, X_t)
+        spread = activations.std(dim=0)
+        outgoing = model[2].weight.data.abs().sum(dim=0)
+        return spread * outgoing
+
+    def _rebuild_with_units(
+        self, model: nn.Sequential, keep_idx, n_classes: int, device
+    ) -> nn.Sequential:
+        """Return a copy of `model` holding only the hidden units in `keep_idx`."""
+        rebuilt = self._build_model(self.n_features_in_, len(keep_idx), n_classes).to(device)
+        rebuilt[0].weight.data = model[0].weight.data[keep_idx].clone()
+        rebuilt[0].bias.data = model[0].bias.data[keep_idx].clone()
+        rebuilt[2].weight.data = model[2].weight.data[:, keep_idx].clone()
+        rebuilt[2].bias.data = model[2].bias.data.clone()
+        return rebuilt
+
+    def _grown(self, model: nn.Sequential, n_classes: int, device) -> nn.Sequential:
+        """Return a copy of `model` with one more hidden unit."""
+        n_hidden = model[0].weight.shape[0]
+        grown = self._build_model(self.n_features_in_, n_hidden + 1, n_classes).to(device)
+        grown[0].weight.data = torch.cat([
+            model[0].weight.data,
+            torch.randn(1, self.n_features_in_, device=device) * 0.1,
+        ], dim=0)
+        grown[0].bias.data = torch.cat([
+            model[0].bias.data, torch.zeros(1, device=device)
+        ])
+        grown[2].weight.data = torch.cat([
+            model[2].weight.data,
+            torch.randn(n_classes, 1, device=device) * 0.1,
+        ], dim=1)
+        grown[2].bias.data = model[2].bias.data.clone()
+        return grown
+
+    @staticmethod
+    def _evaluate(model: nn.Sequential, X_t: "torch.Tensor", y_t: "torch.Tensor"):
+        model.eval()
+        with torch.no_grad():
+            logits = model(X_t)
+            loss = F.cross_entropy(logits, y_t).item()
+            error = 1.0 - (logits.argmax(1) == y_t).float().mean().item()
+        return loss, error
+
+    @staticmethod
+    def _snapshot(model: nn.Sequential) -> dict:
+        return {
+            "n_hidden": model[0].weight.shape[0],
+            "state": {k: v.detach().clone() for k, v in model.state_dict().items()},
+        }
+
+    def _restore(self, snapshot: dict, n_classes: int, device) -> nn.Sequential:
+        model = self._build_model(self.n_features_in_, snapshot["n_hidden"], n_classes).to(device)
+        model.load_state_dict(snapshot["state"])
+        return model
+
     def fit(self, X, y):
         X, y = check_X_y(X, y)
         check_classification_targets(y)

--- a/tests/test_gal_network.py
+++ b/tests/test_gal_network.py
@@ -104,3 +104,89 @@ def test_random_state_makes_training_reproducible(iris_split):
 
     assert first.n_hidden_final_ == second.n_hidden_final_
     assert np.array_equal(first.predict(X_test), second.predict(X_test))
+
+
+def test_validation_policy_builds_a_smaller_network(iris_split):
+    """
+    The point of deciding on held-out evidence is that the network stops
+    growing once extra units stop paying for themselves.
+    """
+    X_train, _, y_train, _ = iris_split
+
+    threshold = GALNetwork(max_epochs=150, growth_policy="error_threshold", random_state=0)
+    validated = GALNetwork(max_epochs=150, growth_policy="validation", random_state=0)
+    threshold.fit(X_train, y_train)
+    validated.fit(X_train, y_train)
+
+    assert validated.n_hidden_final_ < threshold.n_hidden_final_
+    assert validated.growth_policy_ == "validation"
+
+
+def test_validation_policy_records_its_decisions():
+    """
+    Uses separable blobs rather than Iris: on Iris at these settings validation
+    loss keeps improving by more than `tol` at every check, so the policy
+    correctly never touches the architecture and there is no decision to record.
+    """
+    from sklearn.datasets import make_blobs
+
+    X, y = make_blobs(n_samples=300, centers=3, cluster_std=0.1, random_state=0)
+    gal = GALNetwork(
+        max_epochs=150, growth_policy="validation", check_interval=5, random_state=0
+    ).fit(X, y)
+
+    actions = {h["action"] for h in gal.architecture_history_}
+    assert actions <= {"train", "keep", "grow", "prune", "capped"}
+    assert {"grow", "prune"} & actions, "no architecture decision was ever taken"
+    assert all("val_loss" in h for h in gal.architecture_history_)
+    assert gal.best_val_loss_ == pytest.approx(
+        min(h["val_loss"] for h in gal.architecture_history_), abs=1e-6
+    )
+
+
+def test_validation_policy_stops_when_changes_stop_paying(iris_split):
+    X_train, _, y_train, _ = iris_split
+    gal = GALNetwork(
+        max_epochs=2000, growth_policy="validation", patience=2, check_interval=5,
+        random_state=0,
+    ).fit(X_train, y_train)
+
+    assert gal.n_iter_ < 2000
+
+
+def test_falls_back_when_the_data_cannot_support_a_validation_split():
+    """A class with a single member cannot be stratified into a held-out split."""
+    X = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+    y = np.array([0, 0, 0, 1])
+
+    gal = GALNetwork(max_epochs=10, growth_policy="validation", random_state=0).fit(X, y)
+    assert gal.growth_policy_ == "error_threshold"
+    assert gal.predict(X).shape == y.shape
+
+
+@pytest.mark.parametrize(
+    "bad", [{"growth_policy": "bogus"}, {"validation_fraction": 0.0}, {"validation_fraction": 1.5}]
+)
+def test_invalid_growth_settings_are_rejected(bad, iris_split):
+    X_train, _, y_train, _ = iris_split
+    with pytest.raises(ValueError):
+        GALNetwork(**bad).fit(X_train, y_train)
+
+
+def test_pruning_uses_contribution_not_bare_variance():
+    """
+    A nearly constant unit with large outgoing weights still shifts every
+    logit, so activation variance alone is the wrong thing to prune on.
+    """
+    X, y = load_iris(return_X_y=True)
+    gal = GALNetwork(max_epochs=20, random_state=0).fit(X, y)
+
+    import torch
+
+    contributions = gal._contributions(gal.model_, torch.FloatTensor(X))
+    activations = gal._hidden_activations(gal.model_, torch.FloatTensor(X))
+    assert contributions.shape == (gal.n_hidden_final_,)
+    assert (contributions >= 0).all()
+    # Contribution is the spread scaled by outgoing weight, so it differs from
+    # the bare spread whenever the outgoing weights are not all equal.
+    assert not torch.allclose(contributions, activations.std(dim=0))


### PR DESCRIPTION
Phase 1 of the GAL work: move the growth and pruning decisions off fixed thresholds onto held-out evidence.

### What is new

`growth_policy="validation"` holds out `validation_fraction` of the training data and:

- leaves the architecture alone while validation loss is still improving by more than `tol`
- when it stalls, tries **removing** the least useful unit first, and keeps the removal if validation loss does not get worse. A smaller network that validates the same is strictly the better model
- otherwise adds a unit
- stops after `patience` consecutive changes that fail to pay off, restoring the best epoch's parameters

Pruning ranks units by **contribution** (the spread of a unit's activation scaled by the size of its outgoing weights) rather than activation variance. Variance alone says nothing about whether a unit matters: a nearly constant unit with large outgoing weights still shifts every logit.

### It is not the default, and here is why

3 seeds of 5-fold CV, accuracy and mean final hidden units:

| | error_threshold | validation |
|---|:---:|:---:|
| Iris | 0.931 / 22.9 u | 0.869 / **2.6 u** |
| Wine | 0.983 / 6.8 u | 0.970 / **2.1 u** |
| Breast Cancer | 0.975 / 2.0 u | **0.977** / 3.9 u |
| 3 separable blobs | 1.000 / 6.9 u | 0.976 / **3.1 u** |
| 6 separable blobs | **0.967** / 15.1 u | 0.620 / 4.1 u |

It builds far smaller networks and wins outright where capacity is not the constraint, but it under-grows where capacity **is** the constraint.

The cause is measured rather than guessed. A capacity-starved network keeps improving its validation loss slowly, so "loss is still falling" never signals that more units are the missing ingredient. Two obvious fixes were tried and both made it worse:

- lengthening `check_interval` to give each architecture more time: 6 blobs dropped to **2 units and 0.683**, because a longer window makes the improvement test easier to pass
- switching the decision signal from validation loss to validation error: worse everywhere (Iris 0.711, 6 blobs 0.491), since 0/1 error on a small held-out split is too coarse and stops training after 46 to 93 epochs

The conclusion this points at: the growth decision cannot be read off the network's own learning curve. It needs a signal about **what a new unit would buy**, which a randomly initialized unit cannot provide. That is Phase 2.

### Also

- `GALNetwork` now passes `check_estimator` **55/55** under both policies, verified over 10 runs. `check_methods_sample_order_invariance`, the last failure, no longer fires
- falls back to `error_threshold` when the data cannot support a stratified held-out split, with `growth_policy_` recording what was actually used
- `growth_policy`, `validation_fraction` validated in `fit`; `best_val_loss_`, `n_iter_` and per-epoch `action` exposed
- 135 to 143 tests