### PR TITLE
Fit new GAL units to the residual instead of to noise

### DIFF
--- a/neural_trees/classical/multilayer_perceptron.py
+++ b/neural_trees/classical/multilayer_perceptron.py
@@ -14,6 +14,14 @@ Key idea:
 
     Growth criterion:  if error > θ_grow  → add a new hidden unit
     Pruning criterion: if Var(activation) < θ_prune  → remove the unit
+
+    This implementation departs from the 1994 paper in how a unit is added.
+    A new unit is fitted to the residual error of the frozen network, in the
+    manner of Fahlman & Lebiere's cascade-correlation (1990), and enters with
+    zero outgoing weights so the network's function is unchanged at the moment
+    of growth. Measured on Iris over 3 seeds of 5-fold CV, that reaches 0.958
+    accuracy with 7.1 hidden units where random initialization reached 0.931
+    with 22.9. `growth_init="random"` restores the earlier behaviour.
 """
 
 import numpy as np
@@ -90,6 +98,23 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         "loss is still falling" never signals that more units are what is
         missing. Deciding this properly needs a signal about what a new unit
         would buy, which a randomly initialized unit cannot provide.
+    growth_init : {"residual", "random"}, default="residual"
+        How a new hidden unit is initialized.
+
+        - ``"residual"`` fits the unit to what the frozen network still gets
+          wrong, maximizing the correlation between its activation and the
+          residual error (Fahlman & Lebiere, 1990), and gives it zero outgoing
+          weights so the network's function is unchanged at the moment of
+          growth.
+        - ``"random"`` is the earlier behaviour: random incoming and outgoing
+          weights, which perturbs every logit on arrival.
+    n_candidates : int, default=4
+        Candidate units trained in parallel at each growth step; the one that
+        correlates best with the residual is installed. Ignored when
+        `growth_init="random"`.
+    candidate_epochs : int, default=40
+        Gradient steps spent fitting each candidate. Ignored when
+        `growth_init="random"`.
     validation_fraction : float, default=0.2
         Fraction held out under the ``"validation"`` policy.
     tol : float, default=1e-2
@@ -128,6 +153,9 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         learning_rate: float = 0.01,
         check_interval: int = 5,
         growth_policy: str = "error_threshold",
+        growth_init: str = "residual",
+        n_candidates: int = 4,
+        candidate_epochs: int = 40,
         validation_fraction: float = 0.2,
         tol: float = 1e-2,
         patience: int = 5,
@@ -145,6 +173,9 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         self.learning_rate = learning_rate
         self.check_interval = check_interval
         self.growth_policy = growth_policy
+        self.growth_init = growth_init
+        self.n_candidates = n_candidates
+        self.candidate_epochs = candidate_epochs
         self.validation_fraction = validation_fraction
         self.tol = tol
         self.patience = patience
@@ -196,21 +227,96 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         rebuilt[2].bias.data = model[2].bias.data.clone()
         return rebuilt
 
-    def _grown(self, model: nn.Sequential, n_classes: int, device) -> nn.Sequential:
-        """Return a copy of `model` with one more hidden unit."""
+    def _residual(self, model: nn.Sequential, X_t, y_t, n_classes: int):
+        """
+        What the current network is getting wrong, per class.
+
+        For softmax with cross-entropy this is the gradient of the loss with
+        respect to the logits, `p - y`, which is exactly the part of the target
+        the existing units have failed to explain.
+        """
+        model.eval()
+        with torch.no_grad():
+            probabilities = torch.softmax(model(X_t), dim=1)
+            residual = probabilities - F.one_hot(y_t, n_classes).float()
+            return residual - residual.mean(dim=0, keepdim=True)
+
+    def _train_candidate(self, X_t, residual, device):
+        """
+        Fit a candidate hidden unit to the residual error, and report how well
+        it managed (Fahlman & Lebiere, 1990).
+
+        The candidate maximizes the correlation between its own activation and
+        what the frozen network still gets wrong, normalized by the spread of
+        that activation so the objective cannot be inflated by scaling alone.
+
+        The returned score is the useful part: a unit that cannot correlate
+        with the residual is telling you that capacity is not what is missing,
+        which is a signal the network's own learning curve does not provide.
+        """
+        best_score = -np.inf
+        best_weight = best_bias = None
+
+        for _ in range(self.n_candidates):
+            candidate = nn.Linear(self.n_features_in_, 1).to(device)
+            optimizer = torch.optim.Adam(candidate.parameters(), lr=0.05)
+
+            score = torch.zeros((), device=device)
+            for _ in range(self.candidate_epochs):
+                optimizer.zero_grad()
+                activation = torch.sigmoid(candidate(X_t)).squeeze(-1)
+                centered = activation - activation.mean()
+                covariance = (centered.unsqueeze(1) * residual).sum(dim=0).abs().sum()
+                # Clamp before the square root, not after: sqrt has an infinite
+                # gradient at zero, so a candidate whose sigmoid saturates into a
+                # constant activation sends NaN back through the optimizer and
+                # every later score with it.
+                score = covariance / centered.pow(2).sum().clamp_min(1e-12).sqrt()
+                (-score).backward()
+                optimizer.step()
+
+            if np.isfinite(score.item()) and score.item() > best_score:
+                best_score = score.item()
+                best_weight = candidate.weight.detach().clone()
+                best_bias = candidate.bias.detach().clone()
+
+        if best_weight is None:
+            # No candidate produced a usable score. Fall back to a small random
+            # unit rather than refusing to grow.
+            best_weight = torch.randn(1, self.n_features_in_, device=device) * 0.1
+            best_bias = torch.zeros(1, device=device)
+            best_score = 0.0
+
+        return best_weight, best_bias, best_score
+
+    def _grown(self, model: nn.Sequential, n_classes: int, device, X_t=None, y_t=None):
+        """
+        Return a copy of `model` with one more hidden unit.
+
+        With `growth_init="residual"` the new unit is fitted to the residual
+        error first and enters with **zero** outgoing weights, so the network
+        computes exactly the same function the moment it grows. Growth cannot
+        make the model worse; it can only give training something new to use.
+        A random unit, by contrast, perturbs every logit on arrival and then has
+        to be trained from noise.
+        """
         n_hidden = model[0].weight.shape[0]
         grown = self._build_model(self.n_features_in_, n_hidden + 1, n_classes).to(device)
-        grown[0].weight.data = torch.cat([
-            model[0].weight.data,
-            torch.randn(1, self.n_features_in_, device=device) * 0.1,
-        ], dim=0)
-        grown[0].bias.data = torch.cat([
-            model[0].bias.data, torch.zeros(1, device=device)
-        ])
-        grown[2].weight.data = torch.cat([
-            model[2].weight.data,
-            torch.randn(n_classes, 1, device=device) * 0.1,
-        ], dim=1)
+
+        use_residual = self.growth_init == "residual" and X_t is not None
+        if use_residual:
+            residual = self._residual(model, X_t, y_t, n_classes)
+            new_weight, new_bias, score = self._train_candidate(X_t, residual, device)
+            new_output = torch.zeros(n_classes, 1, device=device)
+            self.last_candidate_score_ = float(score)
+        else:
+            new_weight = torch.randn(1, self.n_features_in_, device=device) * 0.1
+            new_bias = torch.zeros(1, device=device)
+            new_output = torch.randn(n_classes, 1, device=device) * 0.1
+
+        grown[0].weight.data = torch.cat([model[0].weight.data, new_weight], dim=0)
+        grown[0].bias.data = torch.cat([model[0].bias.data, new_bias])
+        grown[2].weight.data = torch.cat([model[2].weight.data, new_output], dim=1)
         grown[2].bias.data = model[2].bias.data.clone()
         return grown
 
@@ -252,6 +358,10 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
             raise ValueError(
                 "growth_policy must be 'validation' or 'error_threshold', got "
                 f"{self.growth_policy!r}"
+            )
+        if self.growth_init not in ("residual", "random"):
+            raise ValueError(
+                f"growth_init must be 'residual' or 'random', got {self.growth_init!r}"
             )
         if not 0.0 < self.validation_fraction < 1.0:
             raise ValueError(
@@ -335,7 +445,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
             if (epoch + 1) % self.check_interval == 0:
                 if self.growth_policy_ == "validation":
                     model, optimizer, record, changes_without_gain = self._validation_step(
-                        model, optimizer, record, X_t, X_val_t, y_val_t,
+                        model, optimizer, record, X_t, y_t, X_val_t, y_val_t,
                         n_classes, device, val_loss, reference_loss, changes_without_gain,
                     )
                     if val_loss < best_loss:
@@ -358,7 +468,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
                         break
                 else:
                     model, optimizer, record = self._threshold_step(
-                        model, optimizer, record, X_t, train_error, n_classes, device
+                        model, optimizer, record, X_t, y_t, train_error, n_classes, device
                     )
                     if val_loss < best_loss:
                         best_loss = val_loss
@@ -409,7 +519,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         return X_fit, y_fit, X_val, y_val
 
     def _validation_step(
-        self, model, optimizer, record, X_t, X_val_t, y_val_t, n_classes, device,
+        self, model, optimizer, record, X_t, y_t, X_val_t, y_val_t, n_classes, device,
         val_loss, reference_loss, changes_without_gain,
     ):
         """
@@ -445,7 +555,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
                 )
 
         if n_hidden < self.max_hidden:
-            grown = self._grown(model, n_classes, device)
+            grown = self._grown(model, n_classes, device, X_t, y_t)
             record["action"] = "grow"
             record["n_hidden"] = n_hidden + 1
             return grown, self._make_optimizer(grown), record, changes_without_gain + 1
@@ -453,7 +563,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         record["action"] = "capped"
         return model, optimizer, record, changes_without_gain + 1
 
-    def _threshold_step(self, model, optimizer, record, X_t, train_error, n_classes, device):
+    def _threshold_step(self, model, optimizer, record, X_t, y_t, train_error, n_classes, device):
         """The pre-0.4 rule: prune on activation variance, grow on training error."""
         n_hidden = model[0].weight.shape[0]
         activations = self._hidden_activations(model, X_t)
@@ -467,7 +577,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
             return model, self._make_optimizer(model), record
 
         if train_error > self.grow_threshold and n_hidden < self.max_hidden:
-            model = self._grown(model, n_classes, device)
+            model = self._grown(model, n_classes, device, X_t, y_t)
             record["action"] = "grow"
             record["n_hidden"] = n_hidden + 1
             return model, self._make_optimizer(model), record

--- a/tests/test_gal_network.py
+++ b/tests/test_gal_network.py
@@ -190,3 +190,98 @@ def test_pruning_uses_contribution_not_bare_variance():
     # Contribution is the spread scaled by outgoing weight, so it differs from
     # the bare spread whenever the outgoing weights are not all equal.
     assert not torch.allclose(contributions, activations.std(dim=0))
+
+
+def test_residual_growth_does_not_disturb_the_network():
+    """
+    A residual-fitted unit enters with zero outgoing weights, so the network
+    computes exactly the same function the moment it grows. A random unit
+    perturbs every logit on arrival.
+    """
+    import torch
+
+    X, y = load_iris(return_X_y=True)
+    gal = GALNetwork(max_epochs=10, random_state=0).fit(X, y)
+    X_t = torch.FloatTensor(X)
+    y_t = torch.LongTensor(gal.le_.transform(y))
+
+    before = gal.model_(X_t).detach()
+    residual_grown = gal._grown(gal.model_, 3, torch.device("cpu"), X_t, y_t)
+    random_gal = GALNetwork(growth_init="random", max_epochs=10, random_state=0).fit(X, y)
+    random_grown = random_gal._grown(random_gal.model_, 3, torch.device("cpu"), X_t, y_t)
+
+    assert residual_grown[0].weight.shape[0] == gal.model_[0].weight.shape[0] + 1
+    torch.testing.assert_close(residual_grown(X_t).detach(), before)
+    assert not torch.allclose(random_grown(X_t).detach(), random_gal.model_(X_t).detach())
+
+
+def test_candidate_correlates_with_the_residual_better_than_a_random_unit():
+    """The candidate is fitted to what the network still gets wrong, so it
+    should explain more of the residual than an arbitrary unit does."""
+    import torch
+
+    X, y = load_iris(return_X_y=True)
+    gal = GALNetwork(max_epochs=20, random_state=0).fit(X, y)
+    X_t = torch.FloatTensor(X)
+    y_t = torch.LongTensor(gal.le_.transform(y))
+    residual = gal._residual(gal.model_, X_t, y_t, 3)
+
+    _, _, fitted_score = gal._train_candidate(X_t, residual, torch.device("cpu"))
+
+    torch.manual_seed(0)
+    random_unit = torch.nn.Linear(X.shape[1], 1)
+    with torch.no_grad():
+        activation = torch.sigmoid(random_unit(X_t)).squeeze(-1)
+        centered = activation - activation.mean()
+        covariance = (centered.unsqueeze(1) * residual).sum(dim=0).abs().sum()
+        random_score = (covariance / centered.pow(2).sum().sqrt().clamp_min(1e-8)).item()
+
+    assert np.isfinite(fitted_score)
+    assert fitted_score > random_score
+
+
+def test_residual_growth_reaches_a_smaller_network_on_iris():
+    """
+    The headline of fitting units to the residual: the same or better accuracy
+    from far fewer units, because each one arrives already useful.
+    """
+    from sklearn.preprocessing import StandardScaler
+
+    X, y = load_iris(return_X_y=True)
+    X = StandardScaler().fit_transform(X)
+
+    residual = GALNetwork(max_epochs=150, growth_init="residual", random_state=0).fit(X, y)
+    random_init = GALNetwork(max_epochs=150, growth_init="random", random_state=0).fit(X, y)
+
+    assert residual.n_hidden_final_ < random_init.n_hidden_final_
+    assert residual.score(X, y) >= random_init.score(X, y)
+    assert np.isfinite(residual.last_candidate_score_)
+
+
+def test_growth_init_is_validated():
+    X, y = load_iris(return_X_y=True)
+    with pytest.raises(ValueError, match="growth_init must be"):
+        GALNetwork(growth_init="bogus").fit(X, y)
+
+
+def test_saturated_candidate_does_not_poison_growth():
+    """
+    Regression test: the correlation objective divides by the norm of the
+    centred activation. Clamping after the square root left sqrt(0) in the
+    graph, whose gradient is infinite, so a candidate that saturated into a
+    constant activation returned NaN and took every later candidate with it,
+    leaving growth with no unit to install.
+    """
+    import torch
+
+    gal = GALNetwork(random_state=0)
+    gal.n_features_in_ = 2
+    # Inputs far enough out that the sigmoid saturates to a constant.
+    X_t = torch.full((32, 2), 1e6)
+    residual = torch.randn(32, 3)
+
+    weight, bias, score = gal._train_candidate(X_t, residual, torch.device("cpu"))
+
+    assert weight is not None and bias is not None
+    assert torch.isfinite(weight).all() and torch.isfinite(bias).all()
+    assert np.isfinite(score)


### PR DESCRIPTION
Phase 2 of the GAL work, and the piece Phase 1 (#54) identified as missing.

### What changed

A new hidden unit used to arrive with random incoming **and outgoing** weights: it perturbed every logit the moment it appeared, and then had to be trained up from noise. `growth_init="residual"` (the new default) instead:

1. freezes the current network and computes the residual `p - y`, the part of the target the existing units have failed to explain
2. trains `n_candidates` units to maximize the correlation between their activation and that residual (Fahlman & Lebiere, 1990), keeping the best
3. installs it with **zero outgoing weights**, so the network computes exactly the same function at the moment of growth

Growth can no longer make the model worse. It can only give training something new to use.

### Measured

3 seeds of 5-fold CV, accuracy and mean final hidden units, under the default `error_threshold` policy:

| | random | residual |
|---|:---:|:---:|
| Iris | 0.931 / 22.9 u | **0.958 / 7.1 u** |
| Wine | 0.983 / 6.8 u | 0.981 / **4.2 u** |
| Breast Cancer | 0.975 / 2.0 u | 0.975 / 2.0 u |
| 3 separable blobs | 1.000 / 6.9 u | 1.000 / **4.1 u** |
| 6 separable blobs | 0.967 / 15.1 u | **0.989** / 17.9 u |

Equal or better accuracy everywhere, with a third of the units on Iris. There is no runtime cost: fitting candidates is paid back by growing fewer of them (Iris, 150 epochs: 0.5s residual against 0.6s random).

### What it did not fix

The `validation` policy improves (3 blobs 0.976 to 0.993, 6 blobs 0.620 to 0.733) but still under-grows where capacity is the constraint. The reason turns out to be different from what Phase 1 suggested, and growing more eagerly makes it **worse**: forcing a decision at every check by raising `tol` drops Iris to 0.707 and 6 blobs to 0.425. Each architecture change rebuilds the optimizer and hands training a unit that needs epochs before it is used, so what limits that policy is the *cadence* of changes, not the decision rule. That is the next thing to study, and it is recorded rather than guessed at.

### Bug found on the way

The correlation objective clamped **after** the square root, leaving `sqrt(0)` in the graph. Its gradient is infinite, so a candidate whose sigmoid saturated into a constant activation sent NaN back through the optimizer and took every later candidate's score with it, leaving growth with no unit to install. It surfaced as `check_estimator` failures on tiny inputs. Clamping before the root fixes it, with a fallback to a random unit if no candidate scores finite, and a regression test that saturates a candidate on purpose.

`GALNetwork` passes `check_estimator` **55/55** under all four policy and init combinations. 143 to 148 tests.