### PR TITLE
Enforce coverage and run the notebooks in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,30 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ -v --cov=neural_trees --cov-report=xml
+          pytest tests/ -v --cov=neural_trees --cov-report=xml --cov-fail-under=95
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
+
+  notebooks:
+    # Slower than the unit tests and independent of the Python matrix, so it
+    # runs on its own. Committed notebook outputs go stale silently when the
+    # models change; this fails the build instead.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Execute notebooks
+        run: python scripts/run_notebooks.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,9 @@ open an issue and ask.
    git clone https://github.com/YOUR-USERNAME/neural-trees.git
    cd neural-trees
    ```
-3. **Install** in editable mode with the test extras:
+3. **Install** in editable mode with the development extras:
    ```bash
-   pip install -e .
-   pip install pytest pytest-cov
+   pip install -e ".[dev]"
    ```
 4. **Create a branch** for your change:
    ```bash
@@ -58,6 +57,13 @@ Before opening your PR, please make sure:
 
 - [ ] Your branch is based on the latest `main`.
 - [ ] You have run the tests locally: `pytest tests/`.
+- [ ] Coverage has not dropped below **95%**, which CI enforces:
+      `pytest tests/ --cov=neural_trees --cov-fail-under=95`. It currently sits
+      at 97%, so there is a little room, but new code should come with tests.
+- [ ] `ruff check .` passes. CI pins `ruff==0.16.6`.
+- [ ] If you changed a model, the notebooks still run:
+      `python scripts/run_notebooks.py`. They are committed with their outputs,
+      so a model change can silently turn a printed number into a wrong one.
 - [ ] Code style is consistent with the existing files (PEP 8, four-space
       indentation, plain ASCII in source).
 - [ ] Public functions and classes have docstrings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ dev = [
     "pytest-cov>=4.0",
     "matplotlib>=3.4",
     "jupyter",
+    "nbclient>=0.7",
+    "nbformat>=5.0",
     "plotly",
     "ruff>=0.4",
 ]

--- a/scripts/run_notebooks.py
+++ b/scripts/run_notebooks.py
@@ -1,0 +1,59 @@
+"""
+Execute every notebook and fail on the first cell error.
+
+The notebooks are committed with their outputs, which is what makes them
+readable on GitHub, and also what makes them go stale silently: nothing catches
+it when a model change turns a printed number into a wrong one. Running them in
+CI turns that into a build failure.
+
+Notebooks are executed in memory. Outputs are not written back, so CI never
+produces a diff.
+
+Run with:
+    python scripts/run_notebooks.py
+"""
+import sys
+import warnings
+from pathlib import Path
+
+import nbformat
+from nbclient import NotebookClient
+
+NOTEBOOK_DIR = Path(__file__).resolve().parent.parent / "notebooks"
+TIMEOUT_SECONDS = 1800
+
+
+def main() -> int:
+    warnings.filterwarnings("ignore")
+    notebooks = sorted(NOTEBOOK_DIR.glob("*.ipynb"))
+    if not notebooks:
+        print(f"No notebooks found in {NOTEBOOK_DIR}")
+        return 1
+
+    failures = []
+    for path in notebooks:
+        print(f"Executing {path.name} ... ", end="", flush=True)
+        notebook = nbformat.read(path, as_version=4)
+        client = NotebookClient(
+            notebook,
+            timeout=TIMEOUT_SECONDS,
+            kernel_name="python3",
+            allow_errors=False,
+            resources={"metadata": {"path": str(NOTEBOOK_DIR)}},
+        )
+        try:
+            client.execute()
+        except Exception as exc:
+            print("FAILED")
+            failures.append((path.name, f"{type(exc).__name__}: {exc}"))
+        else:
+            print("ok")
+
+    for name, message in failures:
+        print(f"\n--- {name} ---\n{message}", file=sys.stderr)
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two CI gaps, both cases of something being measured but never enforced.

**#36 — coverage had no floor.** The result was uploaded to Codecov, but a drop failed nothing. `--cov-fail-under=95` now gates the test job. Coverage is at **96.66%**, so the bar has a little room without being decorative, and `CONTRIBUTING.md` states it.

**#37 — notebooks could go stale silently.** They are committed with their outputs, which is what makes them readable on GitHub and also what hides staleness: nothing catches a model change turning a printed number into a wrong one. A separate `notebooks` job runs `scripts/run_notebooks.py`, which executes all three with nbclient and fails on the first cell error. Outputs are executed in memory and never written back, so CI produces no diff.

The job is separate from the test matrix because it is slower and does not vary by Python version.

Also: `nbclient` and `nbformat` move into the dev extras so `pip install -e ".[dev]"` covers what CI needs, and the PR checklist in `CONTRIBUTING.md` gains the coverage bar, the pinned ruff, and the notebook check.

Closes #36
Closes #37