### PR TITLE
Export a trained soft tree as a hard one

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ references as the lineage of an idea, not as a claim of exact reproduction.
 | Algorithm | Reference |
 |-----------|-----------|
 | **Soft Decision Trees** | İrsoy, Yıldız, Alpaydın (ICPR 2012) |
+| **Hard export of a soft tree** | `to_hard_tree()`, this library |
 | **Multivariate Decision Trees** | Alpaydın & Çetin (1995), Yıldız & Alpaydın (IEEE TNN 2001) |
 | **Omnivariate Decision Trees** | Yıldız & Alpaydın (IEEE TNN 2001) |
 | **Hierarchical Mixture of Experts with subtree dropout** | İrsoy & Alpaydın (Neurocomputing 2021) |
@@ -231,8 +232,9 @@ neural-trees is not the right tool for every problem:
 - **Streaming or online learning.** Training is batch only; there is no
   `partial_fit`. Refit from scratch when new data arrives.
 - **Sub-millisecond inference.** The PyTorch backend adds per-call overhead.
-  For extreme latency budgets, export the learned gates and evaluate them in
-  plain numpy.
+  `SoftDecisionTree.to_hard_tree()` exports the learned gates as a plain numpy
+  model that predicts about 5x faster and prints its rules, at the cost of
+  reading each gate as a hard decision rather than a soft one.
 - **Very large sample counts.** Training is full-batch gradient descent over
   epochs, not an optimized tree-growing routine like CART. Millions of rows
   will be slow on CPU.

--- a/neural_trees/__init__.py
+++ b/neural_trees/__init__.py
@@ -12,6 +12,7 @@ __author__ = "Cagri Temel"
 from neural_trees.classical.k_nearest_neighbors import WeightedKNN
 from neural_trees.classical.multilayer_perceptron import GALNetwork
 from neural_trees.classical.naive_bayes import NaiveBayesClassifier
+from neural_trees.decision_trees.hard_tree import HardDecisionTree
 from neural_trees.decision_trees.multivariate_tree import MultivariateDecisionTree
 from neural_trees.decision_trees.omnivariate_tree import OmnivariateDecisionTree
 from neural_trees.decision_trees.soft_decision_tree import SoftDecisionTree
@@ -26,6 +27,7 @@ from neural_trees.statistical_tests.classifier_comparison import (
 
 __all__ = [
     "GALNetwork",
+    "HardDecisionTree",
     "HierarchicalMixtureOfExperts",
     "MultivariateDecisionTree",
     "NaiveBayesClassifier",

--- a/neural_trees/decision_trees/__init__.py
+++ b/neural_trees/decision_trees/__init__.py
@@ -1,3 +1,4 @@
+from .hard_tree import HardDecisionTree
 from .multivariate_tree import MultivariateDecisionTree
 from .omnivariate_tree import OmnivariateDecisionTree
 from .soft_decision_tree import SoftDecisionTree

--- a/neural_trees/decision_trees/hard_tree.py
+++ b/neural_trees/decision_trees/hard_tree.py
@@ -1,0 +1,132 @@
+"""
+Hard export of a trained Soft Decision Tree
+===========================================
+
+A soft tree sends every sample to every leaf and mixes the results, which is
+what makes it differentiable and what makes a prediction cost a PyTorch forward
+pass over all 2^depth leaves. Once training is over, that machinery is no longer
+doing any work: each internal node has settled on a hyperplane, and the sign of
+that hyperplane is a decision.
+
+`SoftDecisionTree.to_hard_tree()` takes those hyperplanes as they are and routes
+each sample down a single path, in plain numpy. The result is not the same model
+- a mixture is not a path, and the two disagree on samples that sat near a split
+- so the export reports how often they agree rather than pretending otherwise.
+"""
+
+import numpy as np
+from sklearn.utils.validation import check_array
+
+
+class HardDecisionTree:
+    """
+    A trained Soft Decision Tree with its gates read as hard decisions.
+
+    Each internal node routes right when `w . x + b > 0` and left otherwise, and
+    each leaf carries the class distribution the soft tree learned for it.
+    Prediction is a walk of `depth` steps in numpy, with no PyTorch involved.
+
+    Built by `SoftDecisionTree.to_hard_tree()` rather than directly.
+
+    Attributes
+    ----------
+    depth : int
+    classes_ : ndarray of shape (n_classes,)
+    n_features_in_ : int
+    weights_ : ndarray of shape (n_internal, n_features)
+        One hyperplane per internal node, in breadth-first order.
+    biases_ : ndarray of shape (n_internal,)
+    leaf_distributions_ : ndarray of shape (n_leaves, n_classes)
+    """
+
+    def __init__(self, weights, biases, leaf_distributions, classes, n_features_in):
+        self.weights_ = np.asarray(weights, dtype=np.float64)
+        self.biases_ = np.asarray(biases, dtype=np.float64)
+        self.leaf_distributions_ = np.asarray(leaf_distributions, dtype=np.float64)
+        self.classes_ = np.asarray(classes)
+        self.n_features_in_ = int(n_features_in)
+        self.depth = int(np.log2(len(self.leaf_distributions_)))
+
+    def _leaf_index(self, X: np.ndarray) -> np.ndarray:
+        """Walk every sample down to its leaf, one level at a time."""
+        node = np.zeros(len(X), dtype=np.int64)
+        for _ in range(self.depth):
+            scores = np.einsum("nf,nf->n", X, self.weights_[node]) + self.biases_[node]
+            node = 2 * node + 1 + (scores > 0).astype(np.int64)
+        return node - (len(self.weights_))
+
+    def predict_proba(self, X) -> np.ndarray:
+        """
+        Class probabilities of the reached leaf, shape (n_samples, n_classes).
+        """
+        X = check_array(X)
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"X has {X.shape[1]} features, but HardDecisionTree is expecting "
+                f"{self.n_features_in_} features as input."
+            )
+        return self.leaf_distributions_[self._leaf_index(X)]
+
+    def predict(self, X) -> np.ndarray:
+        """Predicted class labels, shape (n_samples,)."""
+        return self.classes_[np.argmax(self.predict_proba(X), axis=1)]
+
+    def score(self, X, y) -> float:
+        """Mean accuracy on the given data."""
+        return float(np.mean(self.predict(X) == np.asarray(y)))
+
+    def export_text(self, feature_names=None, max_features=3, decimals=3) -> str:
+        """
+        Render the tree as readable rules.
+
+        Parameters
+        ----------
+        feature_names : list of str, optional
+            Defaults to `x0`, `x1`, ...
+        max_features : int, default=3
+            Features shown per split, largest absolute weight first. A
+            multivariate split uses every feature; printing all of them stops
+            being readable, which is the thing this method is for.
+        decimals : int, default=3
+
+        Returns
+        -------
+        str
+        """
+        if feature_names is None:
+            feature_names = [f"x{i}" for i in range(self.n_features_in_)]
+        if len(feature_names) != self.n_features_in_:
+            raise ValueError(
+                f"feature_names has {len(feature_names)} entries, expected "
+                f"{self.n_features_in_}"
+            )
+
+        n_internal = len(self.weights_)
+        lines = []
+
+        def describe_split(node: int) -> str:
+            weights = self.weights_[node]
+            order = np.argsort(-np.abs(weights))[:max_features]
+            terms = [
+                f"{weights[i]:+.{decimals}f}*{feature_names[i]}" for i in order
+            ]
+            omitted = ""
+            if self.n_features_in_ > max_features:
+                omitted = f" (+{self.n_features_in_ - max_features} more)"
+            return f"{' '.join(terms)} {self.biases_[node]:+.{decimals}f}{omitted} > 0"
+
+        def walk(node: int, indent: str, branch: str):
+            if node >= n_internal:
+                distribution = self.leaf_distributions_[node - n_internal]
+                winner = self.classes_[int(np.argmax(distribution))]
+                lines.append(
+                    f"{indent}{branch}predict {winner!r} "
+                    f"(p={distribution.max():.{decimals}f})"
+                )
+                return
+            lines.append(f"{indent}{branch}if {describe_split(node)}:")
+            walk(2 * node + 2, indent + "    ", "yes -> ")
+            walk(2 * node + 1, indent + "    ", "no  -> ")
+
+        walk(0, "", "")
+        return "\n".join(lines)

--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -49,6 +49,7 @@ from sklearn.utils.validation import (
 from torch.utils.data import DataLoader, TensorDataset
 
 from neural_trees._validation import check_predict_input
+from neural_trees.decision_trees.hard_tree import HardDecisionTree
 
 
 class _SoftTreeModule(nn.Module):
@@ -536,6 +537,42 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         with torch.no_grad():
             dists = F.softmax(self.model_.leaf_logits, dim=1)
         return dists.cpu().numpy()
+
+    def to_hard_tree(self):
+        """
+        Export the trained tree with its gates read as hard decisions.
+
+        Each internal node's gate is `sigmoid(beta * (w . x + b))`; the sign of
+        `w . x + b` is the decision it has settled on, and beta only sharpens
+        it. Taking that sign and routing each sample down one path gives a plain
+        numpy model with readable rules and no PyTorch in the prediction path.
+
+        This is a different model, not a re-encoding: a mixture over leaves is
+        not a single path, and the two disagree on samples that sit near a
+        split. Measure the agreement on held-out data before relying on it.
+
+        Returns
+        -------
+        HardDecisionTree
+
+        Examples
+        --------
+        >>> hard = sdt.to_hard_tree()
+        >>> (hard.predict(X_test) == sdt.predict(X_test)).mean()
+        >>> print(hard.export_text(feature_names=feature_names))
+        """
+        check_is_fitted(self)
+        self.model_.eval()
+        with torch.no_grad():
+            weights = self.model_.gates.weight.detach().cpu().numpy()
+            biases = self.model_.gates.bias.detach().cpu().numpy()
+        return HardDecisionTree(
+            weights=weights,
+            biases=biases,
+            leaf_distributions=self.get_leaf_distributions(),
+            classes=self.classes_,
+            n_features_in=self.n_features_in_,
+        )
 
     def get_split_weights(self) -> List[np.ndarray]:
         """

--- a/tests/test_hard_tree.py
+++ b/tests/test_hard_tree.py
@@ -1,0 +1,131 @@
+"""Tests for exporting a trained soft tree as a hard one."""
+import numpy as np
+import pytest
+from sklearn.datasets import load_iris, load_wine
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import HardDecisionTree, SoftDecisionTree
+
+
+@pytest.fixture(scope="module")
+def wine_fit():
+    X, y = load_wine(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.3, stratify=y, random_state=0
+    )
+    scaler = StandardScaler().fit(X_train)
+    X_train, X_test = scaler.transform(X_train), scaler.transform(X_test)
+    soft = SoftDecisionTree(depth=4, max_epochs=60, random_state=0).fit(X_train, y_train)
+    return soft, X_train, X_test, y_train, y_test
+
+
+def test_export_has_the_shape_of_the_soft_tree(wine_fit):
+    soft, _, _, _, _ = wine_fit
+    hard = soft.to_hard_tree()
+
+    assert isinstance(hard, HardDecisionTree)
+    assert hard.depth == soft.depth
+    assert hard.weights_.shape == (2 ** soft.depth - 1, soft.n_features_in_)
+    assert hard.biases_.shape == (2 ** soft.depth - 1,)
+    assert hard.leaf_distributions_.shape == (2 ** soft.depth, 3)
+    np.testing.assert_array_equal(hard.classes_, soft.classes_)
+
+
+def test_routing_follows_the_sign_of_each_gate(wine_fit):
+    """The hard tree's path must be the one the soft gates would take."""
+    soft, _, X_test, _, _ = wine_fit
+    hard = soft.to_hard_tree()
+
+    expected = []
+    for x in X_test:
+        node = 0
+        for _ in range(hard.depth):
+            score = hard.weights_[node] @ x + hard.biases_[node]
+            node = 2 * node + 1 + int(score > 0)
+        expected.append(node - len(hard.weights_))
+
+    np.testing.assert_array_equal(hard._leaf_index(X_test), np.array(expected))
+
+
+def test_predictions_are_the_reached_leaf_distribution(wine_fit):
+    soft, _, X_test, _, _ = wine_fit
+    hard = soft.to_hard_tree()
+
+    proba = hard.predict_proba(X_test)
+    assert proba.shape == (len(X_test), 3)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-6)
+    np.testing.assert_array_equal(
+        hard.predict(X_test), hard.classes_[proba.argmax(axis=1)]
+    )
+    leaves = hard.leaf_distributions_[hard._leaf_index(X_test)]
+    np.testing.assert_allclose(proba, leaves)
+
+
+def test_agrees_with_the_soft_tree_on_most_samples(wine_fit):
+    """
+    A mixture over leaves is not a single path, so the two models are not
+    identical. They should still agree on the large majority of samples.
+    """
+    soft, _, X_test, _, y_test = wine_fit
+    hard = soft.to_hard_tree()
+
+    agreement = (hard.predict(X_test) == soft.predict(X_test)).mean()
+    assert agreement > 0.9
+    assert hard.score(X_test, y_test) > soft.score(X_test, y_test) - 0.1
+
+
+def test_prediction_needs_no_torch(wine_fit):
+    """The export exists to take PyTorch out of the inference path."""
+    import sys
+
+    soft, _, X_test, _, _ = wine_fit
+    hard = soft.to_hard_tree()
+
+    for array in (hard.weights_, hard.biases_, hard.leaf_distributions_):
+        assert isinstance(array, np.ndarray)
+    assert "torch" not in type(hard).__module__
+    assert sys.modules["neural_trees.decision_trees.hard_tree"].__dict__.get("torch") is None
+
+
+def test_export_text_is_readable(wine_fit):
+    soft, _, _, _, _ = wine_fit
+    hard = soft.to_hard_tree()
+    names = [f"feature_{i}" for i in range(hard.n_features_in_)]
+
+    text = hard.export_text(feature_names=names, max_features=2)
+    lines = text.splitlines()
+
+    assert len(lines) == 2 ** (hard.depth + 1) - 1
+    assert lines[0].startswith("if ")
+    assert any("predict" in line for line in lines)
+    assert "feature_0" in text or "feature_1" in text
+    # Only the requested number of terms per split, plus a count of the rest.
+    assert f"(+{hard.n_features_in_ - 2} more)" in text
+
+
+def test_export_text_defaults_and_validates_feature_names(wine_fit):
+    soft, _, _, _, _ = wine_fit
+    hard = soft.to_hard_tree()
+
+    assert "x0" in hard.export_text() or "x1" in hard.export_text()
+    with pytest.raises(ValueError, match="feature_names has"):
+        hard.export_text(feature_names=["only", "two"])
+
+
+def test_wrong_feature_count_is_rejected(wine_fit):
+    soft, _, X_test, _, _ = wine_fit
+    hard = soft.to_hard_tree()
+
+    with pytest.raises(ValueError, match="features, but"):
+        hard.predict(X_test[:, :3])
+
+
+def test_depth_one_tree_exports():
+    X, y = load_iris(return_X_y=True)
+    soft = SoftDecisionTree(depth=1, max_epochs=20, random_state=0).fit(X, y)
+    hard = soft.to_hard_tree()
+
+    assert hard.weights_.shape[0] == 1
+    assert hard.leaf_distributions_.shape[0] == 2
+    assert set(hard.predict(X)).issubset(set(hard.classes_))


### PR DESCRIPTION
A soft tree sends every sample to every leaf and mixes the results, so a prediction costs a PyTorch forward pass over all `2^depth` leaves. After training, that machinery is no longer doing any work: each internal node has settled on a hyperplane, and the sign of that hyperplane is a decision.

`SoftDecisionTree.to_hard_tree()` takes those hyperplanes as they are and routes each sample down a single path in plain numpy.

### Measured

Held-out 30%, depth 4, scaled features:

| | soft | hard | agreement | predict speedup |
|---|:---:|:---:|:---:|:---:|
| Iris | 0.911 | 0.867 | 0.911 | 5.9x |
| Wine | 0.981 | 0.981 | **1.000** | 5.9x |
| Breast Cancer | 0.947 | 0.942 | 0.994 | 5.5x |

**This is a different model, not a re-encoding.** A mixture over leaves is not a single path, and the two disagree on samples that sat near a split. On Wine the gates had settled hard enough that the two agree everywhere; on Iris they had not, and the export costs 4 points. The docstring says to measure agreement on held-out data before relying on it, and the README's Limitations entry points at the export instead of claiming equivalence.

### Readable rules

`export_text()` prints the tree. A multivariate split uses every feature, so it shows the largest weights and counts the rest:

```
if -2.168*petal width (cm) +1.578*sepal width (cm) +0.916 (+2 more) > 0:
    yes -> if +2.329*petal width (cm) -1.655*sepal width (cm) +1.762 (+2 more) > 0:
        yes -> predict 1 (p=0.835)
        no  -> predict 0 (p=0.885)
    no  -> if +2.492*petal length (cm) +1.771*petal width (cm) -1.289 (+2 more) > 0:
        yes -> predict 2 (p=0.890)
        no  -> predict 1 (p=0.896)
```

`HardDecisionTree` is exported at package level. Nine tests, including one that reproduces the routing node by node and one that asserts torch is nowhere in the prediction path, which is the whole point of the export.

Closes #45