### PR TITLE
Grow the soft tree one level at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ python benchmarks/run_benchmarks.py --seeds 5
 On Wine and Breast Cancer the soft tree closes most of the gap between CART and
 kernel or ensemble methods while staying differentiable. On Iris it does not:
 150 samples over 3 classes is too little data for a depth-4 tree with 15 gates
-trained for 40 epochs, and a single oblique split does better. That is the
+trained for 40 epochs, and a single oblique split does better. `growth="incremental"`
+lets the tree choose its own depth against a validation split rather than being
+given one. That is the
 honest shape of the trade-off, and it is why the comparison scripts in
 [`examples/`](examples) use a hypothesis test rather than a single accuracy
 number.

--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -99,6 +99,50 @@ class _SoftTreeModule(nn.Module):
 
         self.leaf_logits = nn.Parameter(torch.zeros(self.n_leaves, n_classes))
 
+    def deepen(self, n_classes: int, jitter: float = 0.2) -> "_SoftTreeModule":
+        """
+        Return a tree one level deeper, computing very nearly the same function.
+
+        Every current leaf becomes an internal node whose gate is all zeros, so
+        it sends half of its arriving mass down each side, and both of its new
+        children start from the parent's class distribution:
+
+            sum_l mu_l (0.5 Q_l + 0.5 Q_l) = sum_l mu_l Q_l
+
+        The children cannot start *identical*, though. With Q_left = Q_right the
+        mixture does not depend on the new gate at all, so the gate's gradient
+        is exactly zero, and the children receive identical gradients and stay
+        identical forever. The new level would be dead weight: measured on Iris,
+        growing that way reached 0.756 against 0.958 for a tree of the same
+        depth trained from scratch.
+
+        `jitter` breaks that symmetry. The function is preserved only
+        approximately, which is the price of the level being able to learn
+        anything at all. The default is not sensitive: 0.05, 0.2 and 0.5 give
+        0.840, 0.844 and 0.796 on Iris and 0.962, 0.968 and 0.972 on Wine.
+        """
+        n_features = self.gates.weight.shape[1]
+        deeper = _SoftTreeModule(
+            n_features=n_features,
+            n_classes=n_classes,
+            depth=self.depth + 1,
+            penalty_coef=self.penalty_coef,
+            learn_temperature=self.learn_temperature,
+        ).to(self.gates.weight.device)
+
+        with torch.no_grad():
+            deeper.gates.weight[: self.n_internal] = self.gates.weight
+            deeper.gates.bias[: self.n_internal] = self.gates.bias
+            deeper.log_beta[: self.n_internal] = self.log_beta
+            # The old leaves become the new bottom row of gates, neutral.
+            deeper.gates.weight[self.n_internal:] = 0.0
+            deeper.gates.bias[self.n_internal:] = 0.0
+            deeper.log_beta[self.n_internal:] = 0.0
+            children = self.leaf_logits.repeat_interleave(2, dim=0)
+            deeper.leaf_logits[:] = children + jitter * torch.randn_like(children)
+
+        return deeper
+
     def gate_logits(self, x: torch.Tensor) -> torch.Tensor:
         """Temperature-scaled logits for every internal node, shape (batch, n_internal)."""
         return torch.exp(self.log_beta) * self.gates(x)
@@ -220,6 +264,20 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         `"balanced"` uses `n_samples / (n_classes * bincount(y))`, which is what
         an imbalanced target usually needs: without it a rare class contributes
         so little to the loss that the tree can ignore it entirely.
+    growth : {"none", "incremental"}, default="none"
+        How the tree reaches its depth.
+
+        - ``"none"`` builds the complete tree of depth `depth` up front, which
+          is the Frosst & Hinton (2017) formulation.
+        - ``"incremental"`` starts from a single split and deepens one level at
+          a time, keeping a level only if it improves validation loss
+          (Irsoy, Yildiz & Alpaydin, ICPR 2012). `depth` becomes an upper bound
+          and `tree_depth_` reports what was actually kept. Requires a
+          validation split, so `validation_fraction` applies whether or not
+          `early_stopping` is on, and the `max_epochs` budget is divided across
+          rounds rather than spent per round. That last point matters in
+          practice: a budget that trains a fixed tree adequately can leave an
+          incremental one under-trained, so raise `max_epochs` when switching.
     learn_temperature : bool, default=False
         Learn a per-node inverse temperature on the gate, so a node can sharpen
         its split instead of saturating in the flat part of the sigmoid
@@ -249,6 +307,12 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         each node on the training data, normalized to sum to 1.
     n_iter_ : int
         Epochs actually run.
+    tree_depth_ : int
+        Depth of the fitted tree. Equals `depth` unless `growth="incremental"`
+        stopped earlier.
+    growth_ : str
+        The growth mode actually used. Falls back to `"none"` when the data is
+        too small to hold out a stratified validation split.
 
     Examples
     --------
@@ -276,6 +340,7 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         verbose: bool = False,
         random_state: Optional[int] = None,
         class_weight=None,
+        growth: str = "none",
         learn_temperature: bool = False,
         early_stopping: bool = False,
         validation_fraction: float = 0.1,
@@ -290,6 +355,7 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         self.verbose = verbose
         self.random_state = random_state
         self.class_weight = class_weight
+        self.growth = growth
         self.learn_temperature = learn_temperature
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
@@ -323,6 +389,10 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         """
         if isinstance(self.depth, bool) or not isinstance(self.depth, int) or self.depth < 1:
             raise ValueError(f"depth must be a positive integer, got {self.depth!r}")
+        if self.growth not in ("none", "incremental"):
+            raise ValueError(
+                f"growth must be 'none' or 'incremental', got {self.growth!r}"
+            )
 
         X, y = check_X_y(X, y)
         check_classification_targets(y)
@@ -345,72 +415,114 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         if self.random_state is not None:
             torch.manual_seed(self.random_state)
 
+        needs_validation = self.early_stopping or self.growth == "incremental"
+        if needs_validation and not 0.0 < self.validation_fraction < 1.0:
+            raise ValueError(
+                f"validation_fraction must be in (0, 1), got {self.validation_fraction!r}"
+            )
+
         X_fit, y_fit, w_fit = X, y_enc, weights
         X_val = y_val = None
-        if self.early_stopping:
-            if not 0.0 < self.validation_fraction < 1.0:
-                raise ValueError(
-                    "validation_fraction must be in (0, 1), got "
-                    f"{self.validation_fraction!r}"
-                )
-            stratify = y_enc if np.bincount(y_enc).min() >= 2 else None
+        if needs_validation and self._can_hold_out(y_enc):
             X_fit, X_val, y_fit, y_val, w_fit, _ = train_test_split(
                 X,
                 y_enc,
                 weights,
                 test_size=self.validation_fraction,
                 random_state=self.random_state,
-                stratify=stratify,
+                stratify=y_enc,
             )
+
+        # Growth needs held-out evidence to decide anything, so without a split
+        # it falls back to building the full depth. growth_ records what ran.
+        self.growth_ = self.growth if X_val is not None else "none"
 
         device = torch.device(self.device)
         X_t = torch.FloatTensor(X_fit).to(device)
         y_t = torch.LongTensor(y_fit).to(device)
         w_t = torch.FloatTensor(w_fit).to(device)
+        X_val_t = torch.FloatTensor(X_val).to(device) if X_val is not None else None
+        y_val_t = torch.LongTensor(y_val).to(device) if X_val is not None else None
 
-        self.model_ = _SoftTreeModule(
-            n_features=self.n_features_in_,
-            n_classes=n_classes,
-            depth=self.depth,
-            penalty_coef=self.penalty_coef,
-            learn_temperature=self.learn_temperature,
-        ).to(device)
-
-        optimizer = torch.optim.Adam(self.model_.parameters(), lr=self.learning_rate)
-        dataset = TensorDataset(X_t, y_t, w_t)
         generator = None
         if self.random_state is not None:
             generator = torch.Generator()
             generator.manual_seed(self.random_state)
         loader = DataLoader(
-            dataset,
+            TensorDataset(X_t, y_t, w_t),
             batch_size=self.batch_size,
             shuffle=True,
             generator=generator,
         )
 
-        if X_val is not None:
-            X_val_t = torch.FloatTensor(X_val).to(device)
-            y_val_t = torch.LongTensor(y_val).to(device)
-
         self.training_history_: List[dict] = []
+
+        if self.growth_ == "incremental":
+            self._fit_incrementally(loader, X_val_t, y_val_t, n_classes, device)
+        else:
+            self.model_ = _SoftTreeModule(
+                n_features=self.n_features_in_,
+                n_classes=n_classes,
+                depth=self.depth,
+                penalty_coef=self.penalty_coef,
+                learn_temperature=self.learn_temperature,
+            ).to(device)
+            optimizer = torch.optim.Adam(self.model_.parameters(), lr=self.learning_rate)
+            _, best_state = self._train_epochs(
+                self.model_, loader, optimizer, self.max_epochs, X_val_t, y_val_t,
+                stop_early=self.early_stopping and X_val_t is not None,
+            )
+            if best_state is not None:
+                self.model_.load_state_dict(best_state)
+
+        self.tree_depth_ = self.model_.depth
+        self.n_iter_ = len(self.training_history_)
+        self.feature_importances_ = self._compute_feature_importances(X_t)
+        return self
+
+    def _can_hold_out(self, y_enc: np.ndarray) -> bool:
+        """
+        Whether the data can spare a stratified validation split.
+
+        A class with a single member cannot be stratified, and a split smaller
+        than the number of classes leaves one unrepresented. Both turn up in
+        sklearn's estimator checks and in genuinely small datasets, so the
+        answer is a fallback rather than an exception.
+        """
+        counts = np.bincount(y_enc)
+        n_val = int(round(len(y_enc) * self.validation_fraction))
+        return bool(
+            counts.min() >= 2
+            and n_val >= len(counts)
+            and len(y_enc) - n_val >= len(counts)
+        )
+
+    def _train_epochs(
+        self, model, loader, optimizer, n_epochs, X_val_t, y_val_t, stop_early=False
+    ):
+        """
+        Run `n_epochs` of training, recording each into `training_history_`.
+
+        Returns the best validation loss seen and a snapshot of the parameters
+        that produced it, or (inf, None) when there is no validation split.
+        """
         best_val_loss = np.inf
         best_state = None
         epochs_without_improvement = 0
+        epoch_offset = len(self.training_history_)
 
-        for epoch in range(self.max_epochs):
-            self.model_.train()
+        for epoch in range(n_epochs):
+            model.train()
             epoch_loss = 0.0
             correct = 0
             total = 0
 
             for X_batch, y_batch, w_batch in loader:
                 optimizer.zero_grad()
-                log_probs = self.model_.log_forward(X_batch)
+                log_probs = model.log_forward(X_batch)
                 per_sample = F.nll_loss(log_probs, y_batch, reduction="none")
                 loss = (per_sample * w_batch).sum() / w_batch.sum().clamp_min(1e-12)
-                penalty = self.model_.penalty(X_batch)
-                total_loss = loss + penalty
+                total_loss = loss + model.penalty(X_batch)
                 total_loss.backward()
                 optimizer.step()
 
@@ -418,23 +530,26 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
                 correct += (log_probs.argmax(dim=1) == y_batch).sum().item()
                 total += X_batch.size(0)
 
-            avg_loss = epoch_loss / total
-            acc = correct / total
-            record = {"epoch": epoch + 1, "loss": avg_loss, "accuracy": acc}
+            record = {
+                "epoch": epoch_offset + epoch + 1,
+                "depth": model.depth,
+                "loss": epoch_loss / total,
+                "accuracy": correct / total,
+            }
 
-            if X_val is not None:
-                self.model_.eval()
+            if X_val_t is not None:
+                model.eval()
                 with torch.no_grad():
-                    val_log_probs = self.model_.log_forward(X_val_t)
-                    val_loss = F.nll_loss(val_log_probs, y_val_t).item()
-                    val_acc = (val_log_probs.argmax(dim=1) == y_val_t).float().mean().item()
-                record["val_loss"] = val_loss
-                record["val_accuracy"] = val_acc
+                    val_log_probs = model.log_forward(X_val_t)
+                    record["val_loss"] = F.nll_loss(val_log_probs, y_val_t).item()
+                    record["val_accuracy"] = (
+                        (val_log_probs.argmax(dim=1) == y_val_t).float().mean().item()
+                    )
 
-                if val_loss < best_val_loss - 1e-6:
-                    best_val_loss = val_loss
+                if record["val_loss"] < best_val_loss - 1e-6:
+                    best_val_loss = record["val_loss"]
                     best_state = {
-                        k: v.detach().clone() for k, v in self.model_.state_dict().items()
+                        k: v.detach().clone() for k, v in model.state_dict().items()
                     }
                     epochs_without_improvement = 0
                 else:
@@ -443,22 +558,84 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
             self.training_history_.append(record)
 
             if self.verbose and (epoch + 1) % 5 == 0:
-                message = f"Epoch {epoch+1}/{self.max_epochs}  loss={avg_loss:.4f}  acc={acc:.4f}"
-                if X_val is not None:
+                message = (
+                    f"Epoch {record['epoch']}  depth={model.depth}  "
+                    f"loss={record['loss']:.4f}  acc={record['accuracy']:.4f}"
+                )
+                if X_val_t is not None:
                     message += f"  val_loss={record['val_loss']:.4f}"
                 print(message)
 
-            if X_val is not None and epochs_without_improvement >= self.n_iter_no_change:
+            if (
+                stop_early
+                and X_val_t is not None
+                and epochs_without_improvement >= self.n_iter_no_change
+            ):
                 if self.verbose:
-                    print(f"Early stopping at epoch {epoch+1}")
+                    print(f"Early stopping at epoch {record['epoch']}")
                 break
 
-        if best_state is not None:
-            self.model_.load_state_dict(best_state)
+        return best_val_loss, best_state
 
-        self.n_iter_ = len(self.training_history_)
-        self.feature_importances_ = self._compute_feature_importances(X_t)
-        return self
+    def _fit_incrementally(self, loader, X_val_t, y_val_t, n_classes, device):
+        """
+        Grow the tree one level at a time, keeping a level only if it earns its
+        place on held-out data (Irsoy, Yildiz & Alpaydin, ICPR 2012).
+
+        Training starts from a single split. After each round the tree is
+        deepened, which by construction leaves the function unchanged, and
+        trained again. A round that fails to improve validation loss is undone
+        and growth stops, so the depth is chosen by the data instead of being
+        fixed in advance.
+
+        The epoch budget is `max_epochs` in total, divided across at most
+        `depth` rounds, so an incremental fit costs about what a fixed-depth fit
+        of the same `max_epochs` costs.
+        """
+        epochs_per_round = max(1, self.max_epochs // max(1, self.depth))
+
+        model = _SoftTreeModule(
+            n_features=self.n_features_in_,
+            n_classes=n_classes,
+            depth=1,
+            penalty_coef=self.penalty_coef,
+            learn_temperature=self.learn_temperature,
+        ).to(device)
+
+        best_loss = np.inf
+        best_state = None
+        best_depth = 1
+
+        while True:
+            optimizer = torch.optim.Adam(model.parameters(), lr=self.learning_rate)
+            round_loss, round_state = self._train_epochs(
+                model, loader, optimizer, epochs_per_round, X_val_t, y_val_t
+            )
+            if round_state is None:  # no validation split available
+                round_loss, round_state = 0.0, {
+                    k: v.detach().clone() for k, v in model.state_dict().items()
+                }
+
+            improved = round_loss < best_loss - 1e-6
+            if improved or best_state is None:
+                best_loss, best_state, best_depth = round_loss, round_state, model.depth
+            elif X_val_t is not None:
+                if self.verbose:
+                    print(f"Depth {model.depth} did not improve, keeping depth {best_depth}")
+                break
+
+            if model.depth >= self.depth:
+                break
+            model = model.deepen(n_classes)
+
+        self.model_ = _SoftTreeModule(
+            n_features=self.n_features_in_,
+            n_classes=n_classes,
+            depth=best_depth,
+            penalty_coef=self.penalty_coef,
+            learn_temperature=self.learn_temperature,
+        ).to(device)
+        self.model_.load_state_dict(best_state)
 
     def _compute_feature_importances(self, X_t: "torch.Tensor") -> np.ndarray:
         """

--- a/tests/test_soft_decision_tree.py
+++ b/tests/test_soft_decision_tree.py
@@ -319,3 +319,144 @@ def test_sample_weight_length_is_validated():
     X, y = load_iris(return_X_y=True)
     with pytest.raises(ValueError):
         SoftDecisionTree(depth=2, max_epochs=2).fit(X, y, sample_weight=np.ones(5))
+
+
+def test_deepening_nearly_preserves_the_function():
+    """
+    A deepened tree splits each leaf's mass evenly between two children that
+    start from the parent's distribution, so the mixture barely moves.
+    """
+    import torch
+
+    X, y = load_wine(return_X_y=True)
+    sdt = SoftDecisionTree(depth=2, max_epochs=30, random_state=0).fit(X, y)
+    X_t = torch.FloatTensor(X)
+
+    before = sdt.model_.log_forward(X_t).detach()
+    deeper = sdt.model_.deepen(3, jitter=0.0)
+    after = deeper.log_forward(X_t).detach()
+
+    assert deeper.depth == sdt.model_.depth + 1
+    torch.testing.assert_close(after, before, rtol=1e-4, atol=1e-5)
+
+
+def test_deepening_breaks_the_symmetry_between_new_children():
+    """
+    Regression test for a dead level. With identical children the mixture does
+    not depend on the new gate, so its gradient is exactly zero and the children
+    receive identical gradients forever. Growing that way reached 0.756 on Iris
+    against 0.958 for a tree of the same depth trained from scratch.
+    """
+    import torch
+
+    X, y = load_wine(return_X_y=True)
+    sdt = SoftDecisionTree(depth=2, max_epochs=10, random_state=0).fit(X, y)
+
+    identical = sdt.model_.deepen(3, jitter=0.0)
+    siblings = identical.leaf_logits.detach()
+    assert torch.allclose(siblings[0::2], siblings[1::2])
+
+    jittered = sdt.model_.deepen(3)
+    siblings = jittered.leaf_logits.detach()
+    assert not torch.allclose(siblings[0::2], siblings[1::2])
+
+    # With identical children the new gates get no gradient at all.
+    X_t = torch.FloatTensor(X)
+    loss = torch.nn.functional.nll_loss(
+        identical.log_forward(X_t), torch.LongTensor(y)
+    )
+    loss.backward()
+    new_gate_grads = identical.gates.weight.grad[identical.n_internal // 2:]
+    assert torch.allclose(new_gate_grads, torch.zeros_like(new_gate_grads), atol=1e-7)
+
+
+def test_incremental_growth_chooses_its_own_depth():
+    """`depth` becomes an upper bound; tree_depth_ reports what was kept."""
+    from sklearn.datasets import make_classification
+    from sklearn.preprocessing import StandardScaler
+
+    X, y = make_classification(
+        n_samples=800, n_features=20, n_informative=6, n_redundant=0,
+        flip_y=0.05, class_sep=0.9, random_state=0,
+    )
+    X = StandardScaler().fit_transform(X)
+
+    grown = SoftDecisionTree(
+        depth=6, max_epochs=60, growth="incremental", random_state=0
+    ).fit(X, y)
+
+    assert 1 <= grown.tree_depth_ <= 6
+    assert grown.model_.depth == grown.tree_depth_
+    assert grown.get_leaf_distributions().shape[0] == 2 ** grown.tree_depth_
+    assert len(grown.get_split_weights()) == 2 ** grown.tree_depth_ - 1
+    assert grown.score(X, y) > 0.7
+
+
+def test_incremental_growth_records_the_depth_of_each_epoch():
+    X, y = load_iris(return_X_y=True)
+    grown = SoftDecisionTree(
+        depth=3, max_epochs=30, growth="incremental", random_state=0
+    ).fit(X, y)
+
+    depths = [record["depth"] for record in grown.training_history_]
+    assert depths[0] == 1
+    assert max(depths) <= 3
+    assert depths == sorted(depths)  # the tree only ever gets deeper
+    assert all("val_loss" in record for record in grown.training_history_)
+
+
+def test_incremental_growth_works_with_the_rest_of_the_api():
+    X, y = load_wine(return_X_y=True)
+    grown = SoftDecisionTree(
+        depth=3, max_epochs=30, growth="incremental", random_state=0
+    ).fit(X, y)
+
+    assert grown.feature_importances_.shape == (X.shape[1],)
+    np.testing.assert_allclose(grown.predict_proba(X).sum(axis=1), 1.0, atol=1e-5)
+    hard = grown.to_hard_tree()
+    assert hard.depth == grown.tree_depth_
+
+
+def test_growth_is_validated():
+    X, y = load_iris(return_X_y=True)
+    with pytest.raises(ValueError, match="growth must be"):
+        SoftDecisionTree(growth="bogus").fit(X, y)
+
+
+def test_growth_falls_back_when_no_validation_split_is_possible():
+    """
+    Growth decides on held-out evidence, and a class with a single member
+    cannot be stratified into a split. The estimator falls back instead of
+    raising, and says so.
+    """
+    X = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]])
+    y = np.array([0, 0, 0, 0, 1])
+
+    sdt = SoftDecisionTree(
+        depth=2, max_epochs=10, growth="incremental", random_state=0
+    ).fit(X, y)
+
+    assert sdt.growth_ == "none"
+    assert sdt.tree_depth_ == 2
+    assert sdt.predict(X).shape == y.shape
+
+
+def test_early_stopping_also_survives_an_unsplittable_dataset():
+    X = np.array([[0.0], [1.0], [2.0], [3.0], [4.0]])
+    y = np.array([0, 0, 0, 0, 1])
+
+    sdt = SoftDecisionTree(
+        depth=2, max_epochs=10, early_stopping=True, random_state=0
+    ).fit(X, y)
+
+    assert sdt.n_iter_ == 10  # nothing to stop early against
+    assert sdt.predict(X).shape == y.shape
+
+
+def test_growth_attribute_reports_incremental_when_it_ran():
+    X, y = load_wine(return_X_y=True)
+    sdt = SoftDecisionTree(
+        depth=3, max_epochs=60, growth="incremental", random_state=0
+    ).fit(X, y)
+
+    assert sdt.growth_ == "incremental"


### PR DESCRIPTION
`SoftDecisionTree` built a complete tree of a depth you had to pick in advance, which is the Frosst & Hinton formulation. `growth="incremental"` instead starts from a single split and deepens while the extra level improves validation loss, which is what İrsoy, Yıldız & Alpaydın (ICPR 2012) do. `depth` becomes an upper bound; `tree_depth_` reports what was kept.

### The interesting part: deepening must *not* preserve the function exactly

Deepening splits each leaf's mass evenly between two children that start from the parent's distribution, so the mixture barely moves and a new level cannot hurt on arrival:

```
sum_l mu_l (0.5 Q_l + 0.5 Q_l) = sum_l mu_l Q_l
```

That looked like the whole design, and it was wrong. With `Q_left = Q_right` the mixture **does not depend on the new gate at all**, so the gate's gradient is exactly zero, and the two children receive identical gradients and stay identical forever. The new level is dead weight. Measured: growing that way reached **0.756** on Iris against **0.958** for a tree of the same depth trained from scratch.

A small jitter on the new leaf logits breaks the symmetry. A sweep over 0.05, 0.2 and 0.5 shows little sensitivity (Iris 0.840 / 0.844 / 0.796, Wine 0.962 / 0.968 / 0.972). There is a regression test that asserts the zero gradient exists with `jitter=0.0`, so this cannot come back quietly.

### Measured

3 seeds of 5-fold CV, accuracy and mean depth kept:

| | fixed | incremental |
|---|:---:|:---:|
| Iris | **0.898** / 4.0 | 0.844 / 4.0 |
| Wine | **0.979** / 4.0 | 0.968 / 4.0 |
| Breast Cancer | 0.974 / 4.0 | **0.976** / 4.0 |
| synthetic 800x20 (bound 6) | 0.857 / 6.0 | **0.872 / 4.5** |

It wins where the right depth is not known in advance, and loses a little on small clean sets where dividing the epoch budget across rounds costs more than adaptive depth buys. The default stays `"none"`, and the docstring says to raise `max_epochs` when switching.

### A latent crash fixed on the way

Growth needs held-out evidence, and a class with a single member cannot be stratified into a split. `early_stopping=True` already had this problem and would raise `The test_size = 1 should be greater or equal to the number of classes` on small inputs. Both now fall back to training on everything, and `growth_` records what actually ran.

`check_estimator`: 62/63 with `growth="incremental"` at a realistic budget, the same as the default, failing only the sample-weight equivalence check that no mini-batch learner can pass. At `max_epochs=20` it is 61/63, because six epochs per round is not enough training for the class-weight check to show an effect, which is the budget-splitting property above.

Closes #44