### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,63 @@
 All notable changes to this project are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] - 2026-09-10
+
+Closes the last of the open work items. The library has no known broken
+behaviour and no open issues.
+
+### Added
+
+- **`SoftDecisionTree.to_hard_tree()`.** After training, each internal node has
+  settled on a hyperplane, and the sign of that hyperplane is a decision.
+  The export routes each sample down a single path in plain numpy, with
+  readable rules through `export_text()`. Held-out 30%, depth 4:
+
+  | | soft | hard | agreement | predict speedup |
+  |---|:---:|:---:|:---:|:---:|
+  | Iris | 0.911 | 0.867 | 0.911 | 5.9x |
+  | Wine | 0.981 | 0.981 | 1.000 | 5.9x |
+  | Breast Cancer | 0.947 | 0.942 | 0.994 | 5.5x |
+
+  It is a different model, not a re-encoding: a mixture over leaves is not a
+  single path. Measure the agreement before relying on it.
+
+- **`SoftDecisionTree(growth="incremental")`.** Starts from a single split and
+  deepens while the extra level improves validation loss, so depth is chosen by
+  the data (İrsoy, Yıldız & Alpaydın, ICPR 2012). `depth` becomes an upper
+  bound and `tree_depth_` reports what was kept. It wins where the right depth
+  is not known in advance (a synthetic 800x20 problem: 0.872 at depth 4.5
+  against 0.857 at a fixed depth 6) and costs a little on small clean sets,
+  where dividing the epoch budget across rounds outweighs adaptive depth. The
+  default stays `"none"`.
+
+### Fixed
+
+- **A deepened level could not learn anything.** Making the deeper tree compute
+  exactly the same function left both new children with identical
+  distributions, and with `Q_left = Q_right` the mixture does not depend on the
+  new gate, so its gradient is exactly zero and the children stay identical
+  forever. Growing that way reached 0.756 on Iris against 0.958 for a tree of
+  the same depth trained from scratch. A small jitter breaks the symmetry.
+- **`early_stopping=True` crashed on datasets too small to split.**
+  `train_test_split` raised `The test_size = 1 should be greater or equal to
+  the number of classes`. Both early stopping and growth now fall back to
+  training on everything, and `growth_` records what ran.
+
+### Changed
+
+- **The HMoE tree is evaluated as stacked banks, in log space.** Gates and
+  experts were `ModuleList`s evaluated one node at a time; a depth-3 tree with
+  branching factor 4 meant 170 small matmuls per forward. Fit wall time on
+  Breast Cancer, 20 epochs: depth 2 b=2 0.7s to 0.2s, depth 3 b=4 3.4s to 1.2s,
+  between 2.4x and 3.2x across shapes. Accuracy over 5 seeds is unchanged or
+  slightly better. Subtree dropout now applies in log space, so a dropped
+  subtree carries exactly zero weight rather than a clamped small number.
+- **CI enforces what it measures.** Coverage is gated at 95% (currently 96.9%),
+  and a separate job executes every notebook and fails on the first cell error,
+  so committed outputs cannot go stale unnoticed.
+- Test suite: 156 to 180.
+
 ## [0.4.0] - 2026-09-09
 
 Work on GALNetwork, plus weighting for the soft tree. Every classifier in the

--- a/neural_trees/__init__.py
+++ b/neural_trees/__init__.py
@@ -6,7 +6,7 @@ Reference:
     Alpaydın, E. (2020). Introduction to Machine Learning (4th ed.). MIT Press.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __author__ = "Cagri Temel"
 
 from neural_trees.classical.k_nearest_neighbors import WeightedKNN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neural-trees"
-version = "0.4.0"
+version = "0.5.0"
 description = "Soft decision trees, mixture of experts, and statistical model comparison tests for Python. Scikit-learn compatible, PyTorch backend."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Closes the last of the open work items. No known broken behaviour, no open issues.

- **`to_hard_tree()`** exports a trained soft tree as plain numpy with readable rules: about 5x faster prediction, 1.000 agreement on Wine and 0.911 on Iris, reported rather than glossed over (#60)
- **`growth="incremental"`** lets the tree choose its own depth against a validation split (#61). The interesting part was that making deepening *exactly* function-preserving is what kills it: identical children give the new gate a zero gradient
- **The HMoE tree is evaluated as stacked banks in log space**: 2.4x to 3.2x faster fits, dropped subtrees carry exactly zero weight (#59)
- **CI enforces what it measures**: coverage gated at 95%, notebooks executed on every PR (#58)
- `early_stopping=True` no longer crashes on datasets too small to split

156 to 180 tests, coverage 96.9%, Python 3.9 to 3.13.