### PR TITLE
Add device="auto" so a GPU gets used when there is one

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Decision boundary learning with Soft Decision Trees on a toy dataset.
 ## Features
 
 - scikit-learn compatible API (`fit`, `predict`, `score`, works in `Pipeline`)
-- PyTorch backend with GPU support
+- PyTorch backend with GPU support (`device="auto"` picks CUDA, then Apple silicon MPS, then CPU)
 - Soft Decision Trees, Hierarchical Mixture of Experts, Multivariate and Omnivariate Trees, GAL
 - Combined 5x2cv F test, McNemar's test, paired t-test for classifier comparison
 - Tested on standard benchmarks (Iris, Wine, Breast Cancer)

--- a/neural_trees/_validation.py
+++ b/neural_trees/_validation.py
@@ -23,3 +23,33 @@ def check_predict_input(estimator, X):
     # torch cannot build a tensor from a negatively strided view, which is what
     # reversed or otherwise reordered input arrives as.
     return np.ascontiguousarray(X)
+
+
+def resolve_device(device):
+    """
+    Turn a `device` parameter into a concrete torch device.
+
+    `"auto"` picks the fastest backend that is actually present: CUDA, then
+    Apple silicon's MPS, then CPU. Anything else is handed to torch as given,
+    so an explicit `"cuda:1"` still works, and an unusable value fails here,
+    with the parameter named, rather than deep inside a forward pass.
+
+    Imported lazily so that the estimators that do not use torch keep working
+    without it installed.
+    """
+    import torch
+
+    if device == "auto":
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        mps = getattr(torch.backends, "mps", None)
+        if mps is not None and mps.is_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+
+    try:
+        return torch.device(device)
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"device must be 'auto' or a torch device string, got {device!r}"
+        ) from exc

--- a/neural_trees/classical/multilayer_perceptron.py
+++ b/neural_trees/classical/multilayer_perceptron.py
@@ -44,7 +44,7 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
 from torch.utils.data import DataLoader, TensorDataset
 
-from neural_trees._validation import check_predict_input
+from neural_trees._validation import check_predict_input, resolve_device
 
 
 class GALNetwork(ClassifierMixin, BaseEstimator):
@@ -132,6 +132,9 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
     momentum : float, default=0.9
         Momentum for the SGD optimizer.
     device : str, default="cpu"
+        PyTorch device. `"auto"` picks CUDA if it is available, then Apple
+        silicon's MPS, then CPU. Resolved once in `fit` and recorded as
+        `device_`.
     verbose : bool, default=False
     random_state : int or None, default=None
         Seed for weight initialization and for the units added during growth.
@@ -377,7 +380,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         self.classes_ = self.le_.classes_
         self.n_features_in_ = X.shape[1]
         n_classes = len(self.classes_)
-        device = torch.device(self.device)
+        device = self.device_ = resolve_device(self.device)
 
         X_fit, y_fit, X_val, y_val = self._split_for_validation(X, y_enc)
         self.growth_policy_ = "validation" if X_val is not None else "error_threshold"
@@ -587,7 +590,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
     def predict_proba(self, X) -> np.ndarray:
         check_is_fitted(self)
         X = check_predict_input(self, X)
-        device = torch.device(self.device)
+        device = self.device_
         self.model_.eval()
         with torch.no_grad():
             logits = self.model_(torch.FloatTensor(X).to(device))

--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -48,7 +48,7 @@ from sklearn.utils.validation import (
 )
 from torch.utils.data import DataLoader, TensorDataset
 
-from neural_trees._validation import check_predict_input
+from neural_trees._validation import check_predict_input, resolve_device
 from neural_trees.decision_trees.hard_tree import HardDecisionTree
 
 
@@ -254,7 +254,10 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         Regularization coefficient for the entropy penalty on internal nodes.
         Higher values encourage more balanced splits.
     device : str, default="cpu"
-        PyTorch device ("cpu" or "cuda").
+        PyTorch device. `"auto"` picks CUDA if it is available, then Apple
+        silicon's MPS, then CPU. Anything else is passed to torch as given, so
+        `"cuda:1"` works. Resolved once in `fit` and recorded as `device_`, so
+        prediction always runs where training did.
     verbose : bool, default=False
         Whether to print training progress.
     random_state : int or None, default=None
@@ -437,7 +440,7 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         # it falls back to building the full depth. growth_ records what ran.
         self.growth_ = self.growth if X_val is not None else "none"
 
-        device = torch.device(self.device)
+        device = self.device_ = resolve_device(self.device)
         X_t = torch.FloatTensor(X_fit).to(device)
         y_t = torch.LongTensor(y_fit).to(device)
         w_t = torch.FloatTensor(w_fit).to(device)
@@ -676,7 +679,7 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
         X = check_predict_input(self, X)
-        device = torch.device(self.device)
+        device = self.device_
         X_t = torch.FloatTensor(X).to(device)
 
         self.model_.eval()

--- a/neural_trees/mixture_of_experts/hierarchical_moe.py
+++ b/neural_trees/mixture_of_experts/hierarchical_moe.py
@@ -56,7 +56,7 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
 from torch.utils.data import DataLoader, TensorDataset
 
-from neural_trees._validation import check_predict_input
+from neural_trees._validation import check_predict_input, resolve_device
 
 
 class _StackedMLP(nn.Module):
@@ -250,6 +250,9 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         Adam learning rate.
     batch_size : int, default=64
     device : str, default="cpu"
+        PyTorch device. `"auto"` picks CUDA if it is available, then Apple
+        silicon's MPS, then CPU. Resolved once in `fit` and recorded as
+        `device_`.
     verbose : bool, default=False
     random_state : int or None, default=None
         Seed for weight initialization and shuffled mini-batches.
@@ -313,7 +316,7 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         self.classes_ = self.le_.classes_
         self.n_features_in_ = X.shape[1]
 
-        device = torch.device(self.device)
+        device = self.device_ = resolve_device(self.device)
         X_t = torch.FloatTensor(X).to(device)
         y_t = torch.LongTensor(y_enc).to(device)
 
@@ -367,7 +370,13 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
 
         # Built here rather than lazily in predict_proba: an estimator must not
         # mutate its own __dict__ while predicting.
-        self.model_double_ = copy.deepcopy(self.model_).to(device).double()
+        #
+        # Always on CPU, whatever device training used. This copy exists to make
+        # predictions independent of row order, which needs float64, and MPS has
+        # no float64 at all while CUDA's is slow. Prediction is a single forward
+        # pass, so the move costs little next to getting the same answer for the
+        # same sample every time.
+        self.model_double_ = copy.deepcopy(self.model_).to("cpu").double()
         self.model_double_.eval()
         return self
 
@@ -375,22 +384,23 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         """
         Predict class probabilities, shape (n_samples, n_classes).
 
-        The forward pass runs in float64. Rows are independent, but BLAS picks
-        different blocking for different memory layouts, so in float32 the same
-        sample scored inside a reordered batch came out up to 1.2e-07 different
-        and a borderline argmax could flip with it. Doubling the width of the
-        predict-time arithmetic puts that at 2.2e-16, which makes predictions a
-        property of the sample rather than of its position in the batch.
-        Training stays in float32.
+        The forward pass runs in float64 on the CPU, whatever device training
+        used. Rows are independent, but BLAS picks different blocking for
+        different memory layouts, so in float32 the same sample scored inside a
+        reordered batch came out up to 1.2e-07 different and a borderline argmax
+        could flip with it. Doubling the width of the predict-time arithmetic
+        puts that at 2.2e-16, which makes a prediction a property of the sample
+        rather than of its position in the batch. It is pinned to the CPU
+        because MPS has no float64 and CUDA's is slow. Training stays float32,
+        on whichever device was chosen.
         """
         check_is_fitted(self)
         X = check_predict_input(self, X)
-        device = torch.device(self.device)
         with torch.no_grad():
             probs = self.model_double_(
-                torch.from_numpy(np.ascontiguousarray(X, dtype=np.float64)).to(device)
+                torch.from_numpy(np.ascontiguousarray(X, dtype=np.float64))
             )
-        return probs.cpu().numpy().astype(np.float64)
+        return probs.numpy().astype(np.float64)
 
 
 

--- a/tests/test_device_selection.py
+++ b/tests/test_device_selection.py
@@ -1,0 +1,98 @@
+"""Tests for how the torch-backed estimators pick a device."""
+import numpy as np
+import pytest
+import torch
+from sklearn.datasets import load_iris
+
+from neural_trees import GALNetwork, HierarchicalMixtureOfExperts, SoftDecisionTree
+from neural_trees._validation import resolve_device
+
+ESTIMATORS = [
+    lambda **kw: SoftDecisionTree(depth=2, max_epochs=3, random_state=0, **kw),
+    lambda **kw: HierarchicalMixtureOfExperts(depth=1, max_epochs=3, random_state=0, **kw),
+    lambda **kw: GALNetwork(max_epochs=5, random_state=0, **kw),
+]
+IDS = ["SoftDecisionTree", "HierarchicalMixtureOfExperts", "GALNetwork"]
+
+
+@pytest.fixture(scope="module")
+def iris():
+    return load_iris(return_X_y=True)
+
+
+def test_auto_resolves_to_something_torch_accepts():
+    device = resolve_device("auto")
+    assert isinstance(device, torch.device)
+    assert device.type in {"cuda", "mps", "cpu"}
+    # Whatever it picked has to actually be usable.
+    torch.zeros(2, device=device)
+
+
+def test_auto_prefers_an_accelerator_when_one_exists():
+    device = resolve_device("auto")
+    if torch.cuda.is_available():
+        assert device.type == "cuda"
+    elif getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+        assert device.type == "mps"
+    else:
+        assert device.type == "cpu"
+
+
+def test_explicit_device_strings_pass_through():
+    assert resolve_device("cpu").type == "cpu"
+
+
+@pytest.mark.parametrize("bad", ["bogus", "cpu:not-a-number", 3.5])
+def test_unusable_device_fails_with_the_parameter_named(bad):
+    with pytest.raises(ValueError, match="device must be"):
+        resolve_device(bad)
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_fit_records_the_resolved_device(make_estimator, iris):
+    X, y = iris
+    estimator = make_estimator(device="auto").fit(X, y)
+
+    assert isinstance(estimator.device_, torch.device)
+    assert estimator.device_ == resolve_device("auto")
+    assert estimator.predict(X).shape == y.shape
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_prediction_does_not_re_resolve_the_device(make_estimator, iris):
+    """
+    Predict must use what fit resolved, not re-read the parameter. Re-resolving
+    would send a model trained on an accelerator through a CPU forward pass, or
+    fail outright if the machine's accelerator appeared or vanished in between.
+    """
+    X, y = iris
+    estimator = make_estimator(device="auto").fit(X, y)
+    estimator.device = "definitely-not-a-device"
+
+    proba = estimator.predict_proba(X)
+    assert proba.shape[0] == len(X)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-4)
+
+
+def test_moe_predicts_on_cpu_whatever_device_it_trained_on(iris):
+    """
+    The float64 copy that makes predictions order-independent is pinned to the
+    CPU: MPS has no float64 at all, and CUDA's is slow.
+    """
+    X, y = iris
+    moe = HierarchicalMixtureOfExperts(
+        depth=1, max_epochs=3, random_state=0, device="auto"
+    ).fit(X, y)
+
+    assert next(moe.model_double_.parameters()).device.type == "cpu"
+    assert next(moe.model_double_.parameters()).dtype == torch.float64
+    np.testing.assert_allclose(
+        moe.predict_proba(X[:20]), moe.predict_proba(X[:20][::-1])[::-1], rtol=1e-9
+    )
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_bad_device_is_rejected_at_fit(make_estimator, iris):
+    X, y = iris
+    with pytest.raises(ValueError, match="device must be"):
+        make_estimator(device="bogus").fit(X, y)


### PR DESCRIPTION
Every torch-backed estimator defaulted to `"cpu"`, while the README feature list said "PyTorch backend with GPU support". Both true, and together they mean a user with a GPU trains on the CPU unless they know to ask.

- `"auto"` resolves to **CUDA**, then Apple silicon **MPS**, then **CPU**
- Resolved once in `fit` and recorded as `device_`; `predict` uses that instead of re-reading the parameter. Re-resolving would send a model trained on an accelerator through a CPU forward pass, or fail outright on a machine whose accelerator appeared or vanished in between. There is a test that mutates `estimator.device` to nonsense after fitting and requires prediction to keep working
- An unusable value fails in `fit` with the parameter named, rather than deep inside a forward pass
- Anything else is passed to torch as given, so `"cuda:1"` still works

### The MPS problem this turned up

`HierarchicalMixtureOfExperts` keeps a float64 copy of the fitted module, which is what makes its predictions independent of row order. MPS has **no float64 support at all**, so `device="auto"` on Apple silicon raised:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework
doesn't support float64. Please use float32 instead.
```

The copy is now pinned to the CPU whatever device training used. That is the right call regardless of MPS: CUDA float64 is slow, prediction is a single forward pass, and the point of the copy is getting the same answer for the same sample every time.

Whether `"auto"` should become the default is deliberately left open, as the issue asked. It would need measuring on real hardware, and on small datasets the transfer overhead can lose to plain CPU.

`check_estimator` stays clean for all three under `device="auto"`. 180 to 196 tests.

Closes #64