### PR TITLE
Weight the loss in GALNetwork and HierarchicalMixtureOfExperts

### DIFF
--- a/neural_trees/classical/multilayer_perceptron.py
+++ b/neural_trees/classical/multilayer_perceptron.py
@@ -24,6 +24,8 @@ Key idea:
     with 22.9. `growth_init="random"` restores the earlier behaviour.
 """
 
+import copy
+
 import numpy as np
 
 try:
@@ -40,8 +42,14 @@ from typing import List, Optional
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
+from sklearn.utils.class_weight import compute_class_weight
 from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
+from sklearn.utils.validation import (
+    _check_sample_weight,
+    check_array,
+    check_is_fitted,
+    check_X_y,
+)
 from torch.utils.data import DataLoader, TensorDataset
 
 from neural_trees._validation import check_predict_input, resolve_device
@@ -139,6 +147,10 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
     random_state : int or None, default=None
         Seed for weight initialization and for the units added during growth.
         Set it for reproducible architectures.
+    class_weight : dict, "balanced" or None, default=None
+        Weights per class, combined multiplicatively with `sample_weight`.
+        `"balanced"` uses `n_samples / (n_classes * bincount(y))`. Without it a
+        rare class contributes so little loss that the model can ignore it.
 
     References
     ----------
@@ -167,6 +179,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         device: str = "cpu",
         verbose: bool = False,
         random_state: Optional[int] = None,
+        class_weight=None,
     ):
         self.initial_hidden = initial_hidden
         self.max_hidden = max_hidden
@@ -187,6 +200,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         self.device = device
         self.verbose = verbose
         self.random_state = random_state
+        self.class_weight = class_weight
 
     def _make_optimizer(self, model: nn.Sequential) -> "torch.optim.Optimizer":
         """A fresh optimizer, needed whenever growth or pruning rebuilds the network."""
@@ -324,12 +338,32 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         return grown
 
     @staticmethod
-    def _evaluate(model: nn.Sequential, X_t: "torch.Tensor", y_t: "torch.Tensor"):
+    def _evaluate(
+        model: nn.Sequential,
+        X_t: "torch.Tensor",
+        y_t: "torch.Tensor",
+        w_t: Optional["torch.Tensor"] = None,
+    ):
+        """
+        Weighted loss and error, which is what growth and pruning have to see.
+
+        Weighting the loss but judging the architecture on unweighted accuracy
+        would let sample_weight change what the network fits while leaving what
+        it *builds* untouched, so a rare class could be worth a lot to the loss
+        and nothing to the decision about capacity.
+        """
         model.eval()
         with torch.no_grad():
             logits = model(X_t)
-            loss = F.cross_entropy(logits, y_t).item()
-            error = 1.0 - (logits.argmax(1) == y_t).float().mean().item()
+            correct = (logits.argmax(1) == y_t).float()
+            if w_t is None:
+                loss = F.cross_entropy(logits, y_t).item()
+                error = 1.0 - correct.mean().item()
+            else:
+                per_sample = F.cross_entropy(logits, y_t, reduction="none")
+                total = w_t.sum().clamp_min(1e-12)
+                loss = ((per_sample * w_t).sum() / total).item()
+                error = 1.0 - ((correct * w_t).sum() / total).item()
         return loss, error
 
     @staticmethod
@@ -344,7 +378,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         model.load_state_dict(snapshot["state"])
         return model
 
-    def fit(self, X, y) -> "GALNetwork":
+    def fit(self, X, y, sample_weight=None) -> "GALNetwork":
         """
         Fit the network, growing and pruning hidden units as it trains.
 
@@ -379,14 +413,26 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         y_enc = self.le_.fit_transform(y)
         self.classes_ = self.le_.classes_
         self.n_features_in_ = X.shape[1]
+
+        weights = _check_sample_weight(sample_weight, X, dtype=np.float64)
+        if self.class_weight is not None:
+            class_weights = compute_class_weight(
+                self.class_weight, classes=np.arange(len(self.classes_)), y=y_enc
+            )
+            weights = weights * class_weights[y_enc]
+        # Normalizing to mean 1 keeps the loss on the same scale as the
+        # unweighted fit, so learning_rate keeps its meaning.
+        weights = weights * (len(weights) / weights.sum())
+
         n_classes = len(self.classes_)
         device = self.device_ = resolve_device(self.device)
 
-        X_fit, y_fit, X_val, y_val = self._split_for_validation(X, y_enc)
+        X_fit, y_fit, w_fit, X_val, y_val = self._split_for_validation(X, y_enc, weights)
         self.growth_policy_ = "validation" if X_val is not None else "error_threshold"
 
         X_t = torch.FloatTensor(X_fit).to(device)
         y_t = torch.LongTensor(y_fit).to(device)
+        w_t = torch.FloatTensor(w_fit).to(device)
         if X_val is not None:
             X_val_t = torch.FloatTensor(X_val).to(device)
             y_val_t = torch.LongTensor(y_val).to(device)
@@ -401,7 +447,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
             generator = torch.Generator()
             generator.manual_seed(self.random_state)
         loader = DataLoader(
-            TensorDataset(X_t, y_t),
+            TensorDataset(X_t, y_t, w_t),
             batch_size=min(self.batch_size, len(X_t)),
             shuffle=True,
             generator=generator,
@@ -420,15 +466,16 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
 
         for epoch in range(self.max_epochs):
             model.train()
-            for X_batch, y_batch in loader:
+            for X_batch, y_batch, w_batch in loader:
                 optimizer.zero_grad()
-                loss = F.cross_entropy(model(X_batch), y_batch)
+                per_sample = F.cross_entropy(model(X_batch), y_batch, reduction="none")
+                loss = (per_sample * w_batch).sum() / w_batch.sum().clamp_min(1e-12)
                 loss.backward()
                 optimizer.step()
 
             # Architecture decisions look at the network as it stands at the end
             # of the epoch, not at one stale mini-batch's logits.
-            train_loss, train_error = self._evaluate(model, X_t, y_t)
+            train_loss, train_error = self._evaluate(model, X_t, y_t, w_t)
             val_loss, val_error = (
                 self._evaluate(model, X_val_t, y_val_t)
                 if X_val is not None
@@ -490,12 +537,20 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
                 )
 
         self.model_ = self._restore(best_snapshot, n_classes, device)
+        # A float64 copy on the CPU, for the same reason HMoE keeps one: rows
+        # are independent, but BLAS blocks differently for different memory
+        # layouts, so in float32 a sample scored inside a reordered batch can
+        # come out slightly different and a borderline argmax can flip. The
+        # effect grows with the network, so it reappears exactly when growth
+        # has done its job.
+        self.model_double_ = copy.deepcopy(self.model_).to("cpu").double()
+        self.model_double_.eval()
         self.n_hidden_final_ = best_snapshot["n_hidden"]
         self.best_val_loss_ = float(best_loss)
         self.n_iter_ = len(self.architecture_history_)
         return self
 
-    def _split_for_validation(self, X: np.ndarray, y_enc: np.ndarray):
+    def _split_for_validation(self, X: np.ndarray, y_enc: np.ndarray, weights: np.ndarray):
         """
         Hold out a validation split, or report that the data cannot support one.
 
@@ -504,22 +559,23 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         back rather than failing.
         """
         if self.growth_policy != "validation":
-            return X, y_enc, None, None
+            return X, y_enc, weights, None, None
 
         counts = np.bincount(y_enc)
         n_classes = len(counts)
         n_val = int(round(len(X) * self.validation_fraction))
         if counts.min() < 2 or n_val < n_classes or len(X) - n_val < n_classes:
-            return X, y_enc, None, None
+            return X, y_enc, weights, None, None
 
-        X_fit, X_val, y_fit, y_val = train_test_split(
+        X_fit, X_val, y_fit, y_val, w_fit, _ = train_test_split(
             X,
             y_enc,
+            weights,
             test_size=self.validation_fraction,
             random_state=self.random_state,
             stratify=y_enc,
         )
-        return X_fit, y_fit, X_val, y_val
+        return X_fit, y_fit, w_fit, X_val, y_val
 
     def _validation_step(
         self, model, optimizer, record, X_t, y_t, X_val_t, y_val_t, n_classes, device,
@@ -588,14 +644,21 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         return model, optimizer, record
 
     def predict_proba(self, X) -> np.ndarray:
+        """
+        Predict class probabilities, shape (n_samples, n_classes).
+
+        The forward pass runs in float64 on the CPU so that a prediction is a
+        property of the sample rather than of its position in the batch.
+        Training stays float32 on whichever device was chosen.
+        """
         check_is_fitted(self)
         X = check_predict_input(self, X)
-        device = self.device_
-        self.model_.eval()
         with torch.no_grad():
-            logits = self.model_(torch.FloatTensor(X).to(device))
+            logits = self.model_double_(
+                torch.from_numpy(np.ascontiguousarray(X, dtype=np.float64))
+            )
             probs = F.softmax(logits, dim=1)
-        return probs.cpu().numpy()
+        return probs.numpy()
 
     def predict(self, X) -> np.ndarray:
         check_is_fitted(self)

--- a/neural_trees/mixture_of_experts/hierarchical_moe.py
+++ b/neural_trees/mixture_of_experts/hierarchical_moe.py
@@ -52,8 +52,14 @@ from typing import List, Optional
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.preprocessing import LabelEncoder
+from sklearn.utils.class_weight import compute_class_weight
 from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
+from sklearn.utils.validation import (
+    _check_sample_weight,
+    check_array,
+    check_is_fitted,
+    check_X_y,
+)
 from torch.utils.data import DataLoader, TensorDataset
 
 from neural_trees._validation import check_predict_input, resolve_device
@@ -256,6 +262,10 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
     verbose : bool, default=False
     random_state : int or None, default=None
         Seed for weight initialization and shuffled mini-batches.
+    class_weight : dict, "balanced" or None, default=None
+        Weights per class, combined multiplicatively with `sample_weight`.
+        `"balanced"` uses `n_samples / (n_classes * bincount(y))`. Without it a
+        rare class contributes so little loss that the model can ignore it.
 
     Examples
     --------
@@ -287,6 +297,7 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         device: str = "cpu",
         verbose: bool = False,
         random_state: Optional[int] = None,
+        class_weight=None,
     ):
         self.depth = depth
         self.branching_factor = branching_factor
@@ -300,8 +311,9 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         self.device = device
         self.verbose = verbose
         self.random_state = random_state
+        self.class_weight = class_weight
 
-    def fit(self, X, y) -> "HierarchicalMixtureOfExperts":
+    def fit(self, X, y, sample_weight=None) -> "HierarchicalMixtureOfExperts":
         if self.dropout_type not in ("subtree", "activation"):
             raise ValueError(
                 "dropout_type must be 'subtree' or 'activation', got "
@@ -316,9 +328,20 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         self.classes_ = self.le_.classes_
         self.n_features_in_ = X.shape[1]
 
+        weights = _check_sample_weight(sample_weight, X, dtype=np.float64)
+        if self.class_weight is not None:
+            class_weights = compute_class_weight(
+                self.class_weight, classes=np.arange(len(self.classes_)), y=y_enc
+            )
+            weights = weights * class_weights[y_enc]
+        # Normalizing to mean 1 keeps the loss on the same scale as the
+        # unweighted fit, so learning_rate keeps its meaning.
+        weights = weights * (len(weights) / weights.sum())
+
         device = self.device_ = resolve_device(self.device)
         X_t = torch.FloatTensor(X).to(device)
         y_t = torch.LongTensor(y_enc).to(device)
+        w_t = torch.FloatTensor(weights).to(device)
 
         self.model_ = _HMoEModule(
             n_features=self.n_features_in_,
@@ -337,7 +360,7 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
             generator = torch.Generator()
             generator.manual_seed(self.random_state)
         loader = DataLoader(
-            TensorDataset(X_t, y_t),
+            TensorDataset(X_t, y_t, w_t),
             batch_size=self.batch_size,
             shuffle=True,
             generator=generator,
@@ -351,10 +374,11 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
             correct = 0
             total = 0
 
-            for X_b, y_b in loader:
+            for X_b, y_b, w_b in loader:
                 optimizer.zero_grad()
                 log_probs = self.model_.log_forward(X_b)
-                loss = F.nll_loss(log_probs, y_b)
+                per_sample = F.nll_loss(log_probs, y_b, reduction="none")
+                loss = (per_sample * w_b).sum() / w_b.sum().clamp_min(1e-12)
                 loss.backward()
                 optimizer.step()
                 total_loss += loss.item() * X_b.size(0)

--- a/tests/test_sample_weighting.py
+++ b/tests/test_sample_weighting.py
@@ -1,0 +1,132 @@
+"""
+Weighting behaves the same way across the torch-backed estimators.
+
+SoftDecisionTree has its own weighting tests; these cover the two that gained
+sample_weight and class_weight later, and assert the properties that make a
+weighting implementation trustworthy rather than merely present.
+"""
+import numpy as np
+import pytest
+from sklearn.datasets import load_iris, make_classification
+from sklearn.metrics import recall_score
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import GALNetwork, HierarchicalMixtureOfExperts
+
+ESTIMATORS = [
+    lambda **kw: HierarchicalMixtureOfExperts(depth=1, max_epochs=20, random_state=0, **kw),
+    lambda **kw: GALNetwork(max_epochs=40, random_state=0, **kw),
+]
+IDS = ["HierarchicalMixtureOfExperts", "GALNetwork"]
+
+
+@pytest.fixture(scope="module")
+def imbalanced():
+    X, y = make_classification(
+        n_samples=600, n_features=10, n_informative=4, n_redundant=0,
+        weights=[0.94, 0.06], flip_y=0.02, class_sep=0.7, random_state=0,
+    )
+    return StandardScaler().fit_transform(X), y
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_uniform_weights_match_the_unweighted_fit(make_estimator):
+    X, y = load_iris(return_X_y=True)
+
+    plain = make_estimator().fit(X, y)
+    weighted = make_estimator().fit(X, y, sample_weight=np.full(len(X), 4.0))
+
+    np.testing.assert_allclose(
+        plain.predict_proba(X), weighted.predict_proba(X), rtol=1e-4, atol=1e-5
+    )
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_zero_weight_removes_a_class(make_estimator):
+    X, y = load_iris(return_X_y=True)
+    weights = np.where(y == 2, 0.0, 1.0)
+
+    estimator = make_estimator().fit(X, y, sample_weight=weights)
+
+    assert list(estimator.classes_) == [0, 1, 2]
+    assert 2 not in set(estimator.predict(X))
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_sample_weight_length_is_validated(make_estimator):
+    X, y = load_iris(return_X_y=True)
+    with pytest.raises(ValueError):
+        make_estimator().fit(X, y, sample_weight=np.ones(7))
+
+
+def test_balanced_class_weight_rescues_the_minority_in_hmoe(imbalanced):
+    X, y = imbalanced
+
+    plain = HierarchicalMixtureOfExperts(depth=2, max_epochs=80, random_state=0).fit(X, y)
+    balanced = HierarchicalMixtureOfExperts(
+        depth=2, max_epochs=80, random_state=0, class_weight="balanced"
+    ).fit(X, y)
+
+    assert recall_score(y, balanced.predict(X), pos_label=1) > recall_score(
+        y, plain.predict(X), pos_label=1
+    ) + 0.3
+    assert balanced.score(X, y) > plain.score(X, y) - 0.05
+
+
+def test_balanced_class_weight_rescues_the_minority_in_gal(imbalanced):
+    """
+    Unweighted, GAL predicted the rare class **zero** times on this problem
+    while reporting 0.930 accuracy, which is exactly the failure class
+    weighting exists to catch.
+    """
+    X, y = imbalanced
+
+    plain = GALNetwork(max_epochs=120, random_state=0).fit(X, y)
+    balanced = GALNetwork(
+        max_epochs=120, random_state=0, class_weight="balanced"
+    ).fit(X, y)
+
+    assert recall_score(y, plain.predict(X), pos_label=1) < 0.2
+    assert recall_score(y, balanced.predict(X), pos_label=1) > 0.5
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_explicit_class_weight_dict_is_accepted(make_estimator, imbalanced):
+    X, y = imbalanced
+    estimator = make_estimator(class_weight={0: 1.0, 1: 10.0}).fit(X, y)
+    assert estimator.predict(X).shape == y.shape
+
+
+def test_gal_growth_criterion_sees_the_weights():
+    """
+    Weighting the loss but judging the architecture on unweighted accuracy
+    would let sample_weight change what the network fits while leaving what it
+    builds untouched. With extreme weights the model must follow them.
+    """
+    from sklearn.datasets import make_blobs
+    from sklearn.model_selection import train_test_split
+
+    X, y = make_blobs(centers=2, random_state=0, cluster_std=20)
+    X_train, X_test, y_train, _ = train_test_split(X, y, test_size=0.5, random_state=0)
+
+    gal = GALNetwork(
+        max_epochs=100, random_state=0, class_weight={0: 1000, 1: 0.0001}
+    ).fit(X_train, y_train)
+
+    # Class 1 is worth ten million times less; nothing should land there.
+    assert set(gal.predict(X_test)) == {0}
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_predictions_do_not_depend_on_row_order(make_estimator):
+    """
+    Both estimators predict in float64 on the CPU for this reason: BLAS blocks
+    differently for different memory layouts, and in float32 a borderline
+    argmax could flip depending on where the sample sat in the batch.
+    """
+    X, y = load_iris(return_X_y=True)
+    estimator = make_estimator().fit(X, y)
+
+    forward = estimator.predict_proba(X[:40])
+    reversed_back = estimator.predict_proba(X[:40][::-1])[::-1]
+    np.testing.assert_allclose(forward, reversed_back, rtol=1e-9, atol=1e-12)


### PR DESCRIPTION
`SoftDecisionTree` took `sample_weight` and `class_weight` (#40, #41); the other two torch-backed models took neither, so the same imbalanced dataset needed a different approach depending on which model you picked.

Both now accept `sample_weight` in `fit` and `class_weight` as a parameter, combined multiplicatively and normalized to mean 1 so `learning_rate` keeps its meaning.

### Measured

600 samples, one class holding 6%, with `class_weight="balanced"`:

| | recall on the rare class | accuracy |
|---|:---:|:---:|
| HMoE | 0.476 → **0.976** | 0.958 → 0.952 |
| GAL | **0.000 → 0.714** | 0.930 → 0.902 |

GAL predicted the rare class **zero times** while reporting 0.930 accuracy. That is precisely the failure class weighting exists to catch, and it was invisible from the accuracy number.

### GAL's architecture search had to see the weights too

Weighting the loss while judging the architecture on unweighted accuracy would let `sample_weight` change what the network *fits* and leave what it *builds* untouched.

That was not academic. With `class_weight={0: 1000, 1: 0.0001}`, the unweighted growth criterion still routed 7 of 50 test samples into the class worth ten million times less, and `check_class_weight_classifiers` failed. With the criterion weighted, nothing lands there and the check passes.

### One more thing found on the way

`GALNetwork` now predicts in float64 on the CPU, as HMoE already did. The float32 row-order sensitivity had come back at larger epoch budgets, which is exactly when growth has built a network big enough for the accumulation to matter. It would have been easy to miss, since the estimator checks pass at the small budget used for testing.

`check_estimator`: both at **62/63**, failing only the sample-weight equivalence check that no stochastic mini-batch learner can satisfy.

Closes #66