### PR TITLE
Vote over several condensed subsets in WeightedKNN

### DIFF
--- a/neural_trees/classical/k_nearest_neighbors.py
+++ b/neural_trees/classical/k_nearest_neighbors.py
@@ -12,6 +12,8 @@ Also implements "Condensed Nearest Neighbor" (Alpaydın, 1997):
     Artificial Intelligence Review, 11, 115-132.
 """
 
+from typing import Optional
+
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.preprocessing import LabelEncoder
@@ -34,8 +36,31 @@ class WeightedKNN(ClassifierMixin, BaseEstimator):
     metric : str, default="euclidean"
         Distance metric: "euclidean" or "manhattan".
     condense : bool, default=False
-        If True, apply condensing: keep only the minimal subset of training
-        samples that correctly classify all others (CNN algorithm).
+        If True, apply condensing: keep only a subset of training samples that
+        correctly classifies all the others (Hart's CNN).
+    n_condensed_sets : int, default=1
+        How many condensed subsets to build and vote over when `condense=True`.
+
+        Condensing is order dependent: which samples end up as prototypes
+        depends on the order they were visited in, and a single pass throws
+        away information that a different order would have kept. Alpaydin
+        (1997) builds several subsets from different orderings and combines
+        their votes, which is where some of the accuracy a single subset gives
+        away comes back. 5-fold accuracy averaged over 5 seeds, by number of
+        subsets, against keeping every sample:
+
+                            1       3       5       9     all
+            Iris          0.917   0.939   0.937   0.937   0.956
+            Wine          0.947   0.955   0.964   0.971   0.966
+            Breast Canc.  0.951   0.963   0.966   0.968   0.966
+
+        Voting beats a single subset everywhere. It reaches the uncondensed
+        classifier on Wine and Breast Cancer while storing roughly a sixth of
+        the data, and closes about half the gap on Iris without closing it.
+
+        Ignored when `condense=False`.
+    random_state : int or None, default=None
+        Seed for the orderings used to build the condensed subsets.
 
     References
     ----------
@@ -49,11 +74,15 @@ class WeightedKNN(ClassifierMixin, BaseEstimator):
         weight_power: float = 2.0,
         metric: str = "euclidean",
         condense: bool = False,
+        n_condensed_sets: int = 1,
+        random_state: Optional[int] = None,
     ):
         self.k = k
         self.weight_power = weight_power
         self.metric = metric
         self.condense = condense
+        self.n_condensed_sets = n_condensed_sets
+        self.random_state = random_state
 
     def _distance(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
         if self.metric == "euclidean":
@@ -108,19 +137,48 @@ class WeightedKNN(ClassifierMixin, BaseEstimator):
         self.classes_ = self.le_.classes_
         self.n_features_in_ = X.shape[1]
 
+        if isinstance(self.n_condensed_sets, bool) or not isinstance(
+            self.n_condensed_sets, int
+        ) or self.n_condensed_sets < 1:
+            raise ValueError(
+                "n_condensed_sets must be a positive integer, got "
+                f"{self.n_condensed_sets!r}"
+            )
+
         if self.condense:
-            self.X_train_, self.y_train_ = self._condense(X, y_enc)
+            rng = np.random.RandomState(self.random_state)
+            self.stores_ = []
+            for i in range(self.n_condensed_sets):
+                # The first subset uses the data as given, so a single set
+                # reproduces the previous behaviour exactly.
+                order = np.arange(len(X)) if i == 0 else rng.permutation(len(X))
+                store_X, store_y = self._condense(X[order], y_enc[order])
+                self.stores_.append((store_X, store_y))
         else:
-            self.X_train_ = X
-            self.y_train_ = y_enc
+            self.stores_ = [(X, y_enc)]
+
+        # The first store is the one an unvoted classifier would use, and the
+        # attribute is part of the public surface.
+        self.X_train_, self.y_train_ = self.stores_[0]
 
         return self
 
     def predict_proba(self, X) -> np.ndarray:
+        """
+        Class probabilities, averaged over the condensed subsets.
+
+        Each subset votes with its own distance-weighted neighbours, and the
+        votes are averaged. With `n_condensed_sets=1` this is a plain weighted
+        KNN over a single store.
+        """
         check_is_fitted(self)
         X = check_predict_input(self, X)
-        dists = self._distance(X, self.X_train_)  # (n_test, n_train)
-        k = min(self.k, len(self.X_train_))
+        votes = [self._vote(X, store_X, store_y) for store_X, store_y in self.stores_]
+        return np.mean(votes, axis=0)
+
+    def _vote(self, X: np.ndarray, store_X: np.ndarray, store_y: np.ndarray) -> np.ndarray:
+        dists = self._distance(X, store_X)  # (n_test, n_store)
+        k = min(self.k, len(store_X))
         n_classes = len(self.classes_)
         probs = np.zeros((len(X), n_classes))
 
@@ -139,7 +197,7 @@ class WeightedKNN(ClassifierMixin, BaseEstimator):
                 weights = 1.0 / (nn_dists ** self.weight_power + 1e-10)
 
             for j, idx in enumerate(nn_idx):
-                probs[i, self.y_train_[idx]] += weights[j]
+                probs[i, store_y[idx]] += weights[j]
 
         probs /= probs.sum(axis=1, keepdims=True)
         return probs

--- a/tests/test_weighted_knn.py
+++ b/tests/test_weighted_knn.py
@@ -110,3 +110,80 @@ def test_k_larger_than_training_set_is_clamped():
     y = np.array([0, 1, 1])
     proba = WeightedKNN(k=50).fit(X, y).predict_proba(np.array([[1.5]]))
     np.testing.assert_allclose(proba.sum(axis=1), 1.0)
+
+
+def test_voting_over_subsets_recovers_what_condensing_gives_away():
+    """
+    Condensing is order dependent, so one pass throws away information a
+    different order would have kept. Voting over several is the point of
+    Alpaydin (1997), and the accuracy it recovers is the reason to bother.
+    """
+    from sklearn.model_selection import StratifiedKFold
+
+    X, y = load_iris(return_X_y=True)
+
+    def score(**kwargs):
+        # Averaged over seeds: on a single split the effect is inside the noise
+        # of which samples happened to become prototypes.
+        accuracies = []
+        for seed in range(3):
+            if kwargs:
+                kwargs = {**kwargs, "random_state": seed}
+            pipe = Pipeline([("s", StandardScaler()), ("k", WeightedKNN(**kwargs))])
+            cv = StratifiedKFold(5, shuffle=True, random_state=seed)
+            accuracies.append(cross_val_score(pipe, X, y, cv=cv).mean())
+        return float(np.mean(accuracies))
+
+    single = score(condense=True)
+    voted = score(condense=True, n_condensed_sets=5)
+
+    assert voted > single
+
+
+def test_each_subset_is_built_from_a_different_ordering():
+    X, y = load_iris(return_X_y=True)
+    knn = WeightedKNN(condense=True, n_condensed_sets=4, random_state=0).fit(X, y)
+
+    assert len(knn.stores_) == 4
+    for store_X, store_y in knn.stores_:
+        assert len(store_X) == len(store_y)
+        assert len(store_X) < len(X)
+
+    # Different orderings keep different prototypes, otherwise voting would be
+    # four copies of one opinion.
+    signatures = {tuple(np.sort(store_X[:, 0])) for store_X, _ in knn.stores_}
+    assert len(signatures) > 1
+
+
+def test_first_subset_reproduces_the_unvoted_classifier():
+    """One set must behave exactly as it did before voting existed."""
+    X, y = load_iris(return_X_y=True)
+
+    one = WeightedKNN(condense=True, n_condensed_sets=1, random_state=0).fit(X, y)
+    many = WeightedKNN(condense=True, n_condensed_sets=3, random_state=0).fit(X, y)
+
+    np.testing.assert_array_equal(one.X_train_, many.stores_[0][0])
+    np.testing.assert_array_equal(one.X_train_, many.X_train_)
+
+
+def test_voting_is_reproducible():
+    X, y = load_iris(return_X_y=True)
+    first = WeightedKNN(condense=True, n_condensed_sets=3, random_state=7).fit(X, y)
+    second = WeightedKNN(condense=True, n_condensed_sets=3, random_state=7).fit(X, y)
+
+    np.testing.assert_allclose(first.predict_proba(X), second.predict_proba(X))
+
+
+def test_n_condensed_sets_is_ignored_without_condensing():
+    X, y = load_iris(return_X_y=True)
+    knn = WeightedKNN(condense=False, n_condensed_sets=5).fit(X, y)
+
+    assert len(knn.stores_) == 1
+    np.testing.assert_array_equal(knn.X_train_, knn.stores_[0][0])
+
+
+@pytest.mark.parametrize("bad", [0, -1, 2.5])
+def test_n_condensed_sets_is_validated(bad):
+    X, y = load_iris(return_X_y=True)
+    with pytest.raises(ValueError, match="n_condensed_sets"):
+        WeightedKNN(condense=True, n_condensed_sets=bad).fit(X, y)


### PR DESCRIPTION
`WeightedKNN` cites Alpaydın (1997), *Voting over Multiple Condensed Nearest Neighbors*, and implemented a single condensed set. The paper's contribution is the plural.

Condensing is order dependent: which samples become prototypes depends on the order they were visited in, so one pass throws away information a different ordering would have kept. `n_condensed_sets` builds that many stores from different orderings, seeded by `random_state`, and `predict_proba` averages their votes. The first store always uses the data as given, so one set reproduces the old behaviour exactly.

### Measured

5-fold accuracy averaged over **5 seeds**, by number of subsets:

| | 1 | 3 | 5 | 9 | all samples |
|---|:---:|:---:|:---:|:---:|:---:|
| Iris | 0.917 | 0.939 | 0.937 | 0.937 | 0.956 |
| Wine | 0.947 | 0.955 | 0.964 | **0.971** | 0.966 |
| Breast Cancer | 0.951 | 0.963 | 0.966 | **0.968** | 0.966 |

Voting beats a single subset everywhere. It reaches the uncondensed classifier on Wine and Breast Cancer while storing roughly **a sixth** of the data, and closes about half the gap on Iris without closing it.

### A note on how those numbers were arrived at

The first set I measured came from one CV seed and looked much better: 0.953 / 0.983 / 0.974, with voting beating the full dataset on two of three. The test I wrote from them then failed on a different split, where voting scored *below* a single subset. Averaged over seeds the effect is real but smaller, so the docstring and the PR use the averaged numbers, and the test averages over seeds too, because on any single split the effect sits inside the noise of which samples happened to become prototypes.

`check_estimator` stays 55/55, with and without voting.

Closes #72