### PR TITLE
Export a trained mixture of experts as hard routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ references as the lineage of an idea, not as a claim of exact reproduction.
 |-----------|-----------|
 | **Soft Decision Trees** | İrsoy, Yıldız, Alpaydın (ICPR 2012) |
 | **Hard export of a soft tree** | `to_hard_tree()`, this library |
+| **Hard routing export of a mixture** | `to_hard_router()`, this library |
 | **Multivariate Decision Trees** | Alpaydın & Çetin (1995), Yıldız & Alpaydın (IEEE TNN 2001) |
 | **Omnivariate Decision Trees** | Yıldız & Alpaydın (IEEE TNN 2001) |
 | **Hierarchical Mixture of Experts with subtree dropout** | İrsoy & Alpaydın (Neurocomputing 2021) |
@@ -240,6 +241,8 @@ neural-trees is not the right tool for every problem:
   `SoftDecisionTree.to_hard_tree()` exports the learned gates as a plain numpy
   model that predicts about 5x faster and prints its rules, at the cost of
   reading each gate as a hard decision rather than a soft one.
+  `HierarchicalMixtureOfExperts.to_hard_router()` does the same for the
+  mixture, evaluating one expert instead of all of them.
 - **Very large sample counts.** Training is full-batch gradient descent over
   epochs, not an optimized tree-growing routine like CART. Millions of rows
   will be slow on CPU.

--- a/neural_trees/__init__.py
+++ b/neural_trees/__init__.py
@@ -16,6 +16,7 @@ from neural_trees.decision_trees.hard_tree import HardDecisionTree
 from neural_trees.decision_trees.multivariate_tree import MultivariateDecisionTree
 from neural_trees.decision_trees.omnivariate_tree import OmnivariateDecisionTree
 from neural_trees.decision_trees.soft_decision_tree import SoftDecisionTree
+from neural_trees.mixture_of_experts.hard_router import HardRoutedExperts
 from neural_trees.mixture_of_experts.hierarchical_moe import (
     HierarchicalMixtureOfExperts,
 )
@@ -28,6 +29,7 @@ from neural_trees.statistical_tests.classifier_comparison import (
 __all__ = [
     "GALNetwork",
     "HardDecisionTree",
+    "HardRoutedExperts",
     "HierarchicalMixtureOfExperts",
     "MultivariateDecisionTree",
     "NaiveBayesClassifier",

--- a/neural_trees/mixture_of_experts/__init__.py
+++ b/neural_trees/mixture_of_experts/__init__.py
@@ -1,1 +1,2 @@
+from .hard_router import HardRoutedExperts
 from .hierarchical_moe import HierarchicalMixtureOfExperts

--- a/neural_trees/mixture_of_experts/hard_router.py
+++ b/neural_trees/mixture_of_experts/hard_router.py
@@ -1,0 +1,157 @@
+"""
+Hard export of a trained Hierarchical Mixture of Experts
+========================================================
+
+A trained mixture evaluates every expert for every sample and blends them by
+the gating weights, so one prediction costs `branching_factor^depth` expert
+forward passes. Once training is over, each gating node has a preferred child
+for any given input, and taking that preference as a decision routes a sample
+down a single path to a single expert.
+
+That is a different model from the mixture, in the same way a hard tree is a
+different model from a soft one: a blend of experts is not one expert. The
+export reports how often the two agree rather than assuming they do.
+
+The experts themselves stay small MLPs, so this is a routing tree over experts,
+not a rule list. What it buys is evaluating one expert instead of all of them.
+"""
+
+import numpy as np
+from sklearn.utils.validation import check_array
+
+
+class HardRoutedExperts:
+    """
+    A trained mixture of experts with its gates read as hard routing decisions.
+
+    Each gating node sends a sample to its highest-weighted child, and the
+    expert reached at the leaf produces the prediction. Everything runs in
+    numpy; no PyTorch is involved.
+
+    Built by `HierarchicalMixtureOfExperts.to_hard_router()` rather than
+    directly.
+
+    Attributes
+    ----------
+    depth : int
+    branching_factor : int
+    classes_ : ndarray of shape (n_classes,)
+    n_features_in_ : int
+    gate_weights_ : list of (W1, b1, W2, b2)
+        One two-layer gating network per internal node, in breadth-first order.
+    expert_weights_ : list of (W1, b1, W2, b2)
+        One two-layer expert network per leaf.
+    """
+
+    def __init__(
+        self, gate_weights, expert_weights, classes, n_features_in, depth, branching_factor
+    ):
+        self.gate_weights_ = gate_weights
+        self.expert_weights_ = expert_weights
+        self.classes_ = np.asarray(classes)
+        self.n_features_in_ = int(n_features_in)
+        self.depth = int(depth)
+        self.branching_factor = int(branching_factor)
+
+    @staticmethod
+    def _mlp(x: np.ndarray, params, activation) -> np.ndarray:
+        weight_in, bias_in, weight_out, bias_out = params
+        hidden = activation(x @ weight_in.T + bias_in)
+        return hidden @ weight_out.T + bias_out
+
+    def _route(self, X: np.ndarray) -> np.ndarray:
+        """Index of the expert each sample is routed to, shape (n_samples,)."""
+        b = self.branching_factor
+        node = np.zeros(len(X), dtype=np.int64)  # index within the current level
+        offset = 0  # first gate index of the current level
+
+        for level in range(self.depth):
+            choice = np.empty(len(X), dtype=np.int64)
+            for position in np.unique(node):
+                rows = node == position
+                logits = self._mlp(X[rows], self.gate_weights_[offset + position], np.tanh)
+                choice[rows] = logits.argmax(axis=1)
+            node = node * b + choice
+            offset += b ** level
+
+        return node
+
+    def predict_proba(self, X) -> np.ndarray:
+        """Class probabilities from the single expert each sample reaches."""
+        X = check_array(X)
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"X has {X.shape[1]} features, but HardRoutedExperts is expecting "
+                f"{self.n_features_in_} features as input."
+            )
+
+        expert_index = self._route(X)
+        proba = np.empty((len(X), len(self.classes_)), dtype=np.float64)
+        for expert in np.unique(expert_index):
+            rows = expert_index == expert
+            logits = self._mlp(X[rows], self.expert_weights_[expert], lambda h: np.maximum(h, 0.0))
+            logits = logits - logits.max(axis=1, keepdims=True)
+            exponentiated = np.exp(logits)
+            proba[rows] = exponentiated / exponentiated.sum(axis=1, keepdims=True)
+        return proba
+
+    def predict(self, X) -> np.ndarray:
+        """Predicted class labels, shape (n_samples,)."""
+        return self.classes_[np.argmax(self.predict_proba(X), axis=1)]
+
+    def score(self, X, y) -> float:
+        """Mean accuracy on the given data."""
+        return float(np.mean(self.predict(X) == np.asarray(y)))
+
+    def route_counts(self, X) -> np.ndarray:
+        """
+        How many samples reach each expert, shape (n_experts,).
+
+        A mixture spreads every sample over all experts, so this is the first
+        thing the export makes visible: whether the tree actually partitions
+        the input or leans on one branch.
+        """
+        X = check_array(X)
+        return np.bincount(self._route(X), minlength=len(self.expert_weights_))
+
+    def export_text(self, feature_names=None, max_features=3, decimals=3) -> str:
+        """
+        Render the routing tree, showing which features drive each gate.
+
+        A gating node is a two-layer network, not a single hyperplane, so there
+        is no exact rule to print. What is shown is each gate's input-layer
+        sensitivity per feature, summed over hidden units, which says what the
+        gate is looking at.
+        """
+        if feature_names is None:
+            feature_names = [f"x{i}" for i in range(self.n_features_in_)]
+        if len(feature_names) != self.n_features_in_:
+            raise ValueError(
+                f"feature_names has {len(feature_names)} entries, expected "
+                f"{self.n_features_in_}"
+            )
+
+        b = self.branching_factor
+        lines = []
+
+        def describe_gate(gate_index: int) -> str:
+            weight_in = self.gate_weights_[gate_index][0]
+            sensitivity = np.abs(weight_in).sum(axis=0)
+            order = np.argsort(-sensitivity)[:max_features]
+            terms = ", ".join(
+                f"{feature_names[i]} ({sensitivity[i]:.{decimals}f})" for i in order
+            )
+            return f"gate on {terms}"
+
+        def walk(level: int, position: int, indent: str):
+            if level == self.depth:
+                lines.append(f"{indent}-> expert {position}")
+                return
+            offset = sum(b ** d for d in range(level))
+            lines.append(f"{indent}{describe_gate(offset + position)}:")
+            for child in range(b):
+                lines.append(f"{indent}  child {child}:")
+                walk(level + 1, position * b + child, indent + "    ")
+
+        walk(0, 0, "")
+        return "\n".join(lines)

--- a/neural_trees/mixture_of_experts/hierarchical_moe.py
+++ b/neural_trees/mixture_of_experts/hierarchical_moe.py
@@ -63,6 +63,7 @@ from sklearn.utils.validation import (
 from torch.utils.data import DataLoader, TensorDataset
 
 from neural_trees._validation import check_predict_input, resolve_device
+from neural_trees.mixture_of_experts.hard_router import HardRoutedExperts
 
 
 class _StackedMLP(nn.Module):
@@ -427,6 +428,44 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         return probs.numpy().astype(np.float64)
 
 
+
+    def to_hard_router(self) -> "HardRoutedExperts":
+        """
+        Export the trained mixture with its gates read as hard routing.
+
+        A trained mixture evaluates every expert for every sample and blends
+        them, so one prediction costs `branching_factor^depth` expert forward
+        passes. Each gating node has a preferred child for any given input;
+        taking that preference as a decision sends a sample down one path to
+        one expert, in numpy.
+
+        This is a different model, not a re-encoding: a blend of experts is not
+        one expert, and the two disagree where the gating was undecided.
+        Measure the agreement on held-out data before relying on it.
+
+        Returns
+        -------
+        HardRoutedExperts
+        """
+        check_is_fitted(self)
+
+        def unpack(bank, index):
+            return (
+                bank.weight_in[index].detach().cpu().numpy().astype(np.float64),
+                bank.bias_in[index].detach().cpu().numpy().astype(np.float64),
+                bank.weight_out[index].detach().cpu().numpy().astype(np.float64),
+                bank.bias_out[index].detach().cpu().numpy().astype(np.float64),
+            )
+
+        module = self.model_
+        return HardRoutedExperts(
+            gate_weights=[unpack(module.gates, i) for i in range(module.n_gates)],
+            expert_weights=[unpack(module.experts, i) for i in range(module.n_experts)],
+            classes=self.classes_,
+            n_features_in=self.n_features_in_,
+            depth=self.depth,
+            branching_factor=self.branching_factor,
+        )
 
     def predict(self, X) -> np.ndarray:
         check_is_fitted(self)

--- a/tests/test_hard_router.py
+++ b/tests/test_hard_router.py
@@ -1,0 +1,139 @@
+"""Tests for exporting a trained mixture of experts as hard routing."""
+import numpy as np
+import pytest
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import HardRoutedExperts, HierarchicalMixtureOfExperts
+
+
+@pytest.fixture(scope="module")
+def wine_fit():
+    X, y = load_wine(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.3, stratify=y, random_state=0
+    )
+    scaler = StandardScaler().fit(X_train)
+    X_train, X_test = scaler.transform(X_train), scaler.transform(X_test)
+    moe = HierarchicalMixtureOfExperts(
+        depth=2, branching_factor=2, max_epochs=80, random_state=0
+    ).fit(X_train, y_train)
+    return moe, X_train, X_test, y_train, y_test
+
+
+def test_export_has_the_shape_of_the_mixture(wine_fit):
+    moe, _, _, _, _ = wine_fit
+    router = moe.to_hard_router()
+
+    assert isinstance(router, HardRoutedExperts)
+    assert router.depth == moe.depth
+    assert router.branching_factor == moe.branching_factor
+    assert len(router.gate_weights_) == moe.model_.n_gates
+    assert len(router.expert_weights_) == moe.model_.n_experts
+    np.testing.assert_array_equal(router.classes_, moe.classes_)
+
+
+def test_routing_follows_each_gate_argmax(wine_fit):
+    """The exported path must be the one the trained gates prefer."""
+    import torch
+
+    moe, _, X_test, _, _ = wine_fit
+    router = moe.to_hard_router()
+    moe.model_.eval()
+
+    with torch.no_grad():
+        log_gates = moe.model_._log_gate_probabilities(torch.FloatTensor(X_test))
+    gates = log_gates.numpy()
+
+    b = router.branching_factor
+    expected = np.zeros(len(X_test), dtype=np.int64)
+    offset = 0
+    for level in range(router.depth):
+        choice = np.array(
+            [gates[i, offset + expected[i], :].argmax() for i in range(len(X_test))]
+        )
+        expected = expected * b + choice
+        offset += b ** level
+
+    np.testing.assert_array_equal(router._route(X_test), expected)
+
+
+def test_predictions_are_one_expert_not_a_blend(wine_fit):
+    moe, _, X_test, _, _ = wine_fit
+    router = moe.to_hard_router()
+
+    proba = router.predict_proba(X_test)
+    assert proba.shape == (len(X_test), 3)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-9)
+    np.testing.assert_array_equal(
+        router.predict(X_test), router.classes_[proba.argmax(axis=1)]
+    )
+
+
+def test_agrees_with_the_mixture_on_most_samples(wine_fit):
+    moe, _, X_test, _, y_test = wine_fit
+    router = moe.to_hard_router()
+
+    agreement = (router.predict(X_test) == moe.predict(X_test)).mean()
+    assert agreement > 0.9
+    assert router.score(X_test, y_test) > moe.score(X_test, y_test) - 0.1
+
+
+def test_route_counts_show_how_the_tree_partitions(wine_fit):
+    """
+    A mixture spreads every sample over all experts, so nothing in it says
+    whether the tree actually partitions the input. The export does.
+    """
+    moe, _, X_test, _, _ = wine_fit
+    router = moe.to_hard_router()
+
+    counts = router.route_counts(X_test)
+    assert counts.shape == (moe.model_.n_experts,)
+    assert counts.sum() == len(X_test)
+
+
+def test_prediction_needs_no_torch(wine_fit):
+    import sys
+
+    moe, _, _, _, _ = wine_fit
+    router = moe.to_hard_router()
+
+    for params in router.gate_weights_ + router.expert_weights_:
+        assert all(isinstance(array, np.ndarray) for array in params)
+    assert sys.modules["neural_trees.mixture_of_experts.hard_router"].__dict__.get("torch") is None
+
+
+def test_export_text_describes_every_gate_and_expert(wine_fit):
+    moe, _, _, _, _ = wine_fit
+    router = moe.to_hard_router()
+    names = [f"feature_{i}" for i in range(router.n_features_in_)]
+
+    text = router.export_text(feature_names=names, max_features=2)
+    assert text.count("gate on") == moe.model_.n_gates
+    assert text.count("-> expert") == moe.model_.n_experts
+    assert "feature_" in text
+
+    with pytest.raises(ValueError, match="feature_names has"):
+        router.export_text(feature_names=["too", "few"])
+
+
+def test_wrong_feature_count_is_rejected(wine_fit):
+    moe, _, X_test, _, _ = wine_fit
+    router = moe.to_hard_router()
+
+    with pytest.raises(ValueError, match="features, but"):
+        router.predict(X_test[:, :4])
+
+
+@pytest.mark.parametrize("depth,branching_factor", [(1, 2), (2, 4), (3, 2)])
+def test_export_works_for_other_tree_shapes(depth, branching_factor):
+    X, y = load_wine(return_X_y=True)
+    X = StandardScaler().fit_transform(X)
+    moe = HierarchicalMixtureOfExperts(
+        depth=depth, branching_factor=branching_factor, max_epochs=20, random_state=0
+    ).fit(X, y)
+
+    router = moe.to_hard_router()
+    assert router.route_counts(X).sum() == len(X)
+    assert set(router.predict(X)).issubset(set(router.classes_))


### PR DESCRIPTION
`SoftDecisionTree.to_hard_tree()` (#45) gave the soft tree a numpy export. The mixture had none, so it was stuck evaluating `branching_factor^depth` experts for every prediction.

`to_hard_router()` takes each gating node's preferred child as a decision and sends a sample down one path to one expert.

### Measured

Held-out 30%, depth 2, branching factor 2:

| | soft | hard | agreement | predict speedup |
|---|:---:|:---:|:---:|:---:|
| Iris | 0.911 | 0.911 | **1.000** | 2.8x |
| Wine | 1.000 | 0.981 | 0.981 | 2.5x |
| Breast Cancer | 0.965 | 0.959 | 0.994 | 2.4x |

The speedup is smaller than the soft tree's 5x, which is expected: an expert is a two-layer MLP, so skipping three of four still leaves real work, whereas a soft tree's leaves are just distributions.

As with #45, this is a **different model**, not a re-encoding. A blend of experts is not one expert, and the two part company where the gating was undecided.

### `route_counts()`

A mixture spreads every sample over all its experts, so nothing in it tells you whether the tree actually partitions the input. The export does. On Wine one of the four experts receives **nothing at all**, which is worth knowing about a model you are about to make deeper.

`export_text()` renders the routing tree with each gate's per-feature sensitivity. Gating nodes are two-layer networks, not hyperplanes, so there is no exact rule to print and the docstring says so rather than implying otherwise.

Closes #69