### PR TITLE
Add warm_start so a fit can be continued

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,11 @@ neural-trees is not the right tool for every problem:
 - **Very high-dimensional data.** Every internal node holds a dense weight
   vector, so parameter count grows as `2^depth x n_features`. Beyond a few
   thousand features, reduce dimensionality first or use a linear model.
-- **Streaming or online learning.** Training is batch only; there is no
-  `partial_fit`. Refit from scratch when new data arrives.
+- **Streaming or online learning.** Training is batch only. `warm_start=True`
+  continues a fit from where the last one stopped, which covers training in
+  stages, but there is no `partial_fit`: mini-batch gradient descent over a
+  second dataset drifts toward that dataset rather than toward the union, so
+  the contract `partial_fit` implies would not hold.
 - **Sub-millisecond inference.** The PyTorch backend adds per-call overhead.
   `SoftDecisionTree.to_hard_tree()` exports the learned gates as a plain numpy
   model that predicts about 5x faster and prints its rules, at the cost of

--- a/neural_trees/classical/multilayer_perceptron.py
+++ b/neural_trees/classical/multilayer_perceptron.py
@@ -152,6 +152,10 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
     random_state : int or None, default=None
         Seed for weight initialization and for the units added during growth.
         Set it for reproducible architectures.
+    warm_start : bool, default=False
+        When True, a second call to `fit` continues from the network the first
+        one left, keeping both its weights and the architecture growth chose,
+        instead of restarting from `initial_hidden`.
     class_weight : dict, "balanced" or None, default=None
         Weights per class, combined multiplicatively with `sample_weight`.
         `"balanced"` uses `n_samples / (n_classes * bincount(y))`. Without it a
@@ -162,6 +166,11 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
     Alpaydın, E. (1994). GAL: Networks that Grow when they Learn and Shrink
     when they Forget. IJPRAI, 8, 391-414.
     """
+
+    # Declared so the type is known where warm_start reads it back, before the
+    # assignment at the end of fit. A bare annotation adds nothing to the
+    # instance, so sklearn's "no attributes set in __init__" check is unaffected.
+    model_: nn.Sequential
 
     def __init__(
         self,
@@ -186,6 +195,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         verbose: bool = False,
         random_state: Optional[int] = None,
         class_weight=None,
+        warm_start: bool = False,
     ):
         self.initial_hidden = initial_hidden
         self.max_hidden = max_hidden
@@ -208,6 +218,7 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         self.verbose = verbose
         self.random_state = random_state
         self.class_weight = class_weight
+        self.warm_start = warm_start
 
     def _make_optimizer(self, model: nn.Sequential) -> "torch.optim.Optimizer":
         """A fresh optimizer, needed whenever growth or pruning rebuilds the network."""
@@ -439,6 +450,23 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         model.load_state_dict(snapshot["state"])
         return model
 
+    def _reuse_existing_model(self, n_classes: int) -> bool:
+        """
+        Whether a previous fit's network can be continued from.
+
+        Refusing loudly when the label set changed is deliberate: silently
+        reinitializing would make warm_start look like it worked while throwing
+        away everything the first fit learned, architecture included.
+        """
+        if not self.warm_start or not hasattr(self, "model_"):
+            return False
+        if len(getattr(self, "classes_", [])) != n_classes:
+            raise ValueError(
+                "warm_start=True requires the same classes across calls to fit; "
+                "the label set changed, and this model cannot grow its output layer."
+            )
+        return True
+
     def fit(self, X, y, sample_weight=None) -> "GALNetwork":
         """
         Fit the network, growing and pruning hidden units as it trains.
@@ -470,9 +498,11 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         check_classification_targets(y)
         if self.random_state is not None:
             torch.manual_seed(self.random_state)
-        self.le_ = LabelEncoder()
-        y_enc = self.le_.fit_transform(y)
-        self.classes_ = self.le_.classes_
+        encoder = LabelEncoder()
+        y_enc = encoder.fit_transform(y)
+        continuing = self._reuse_existing_model(len(encoder.classes_))
+        self.le_ = encoder
+        self.classes_ = encoder.classes_
         self.n_features_in_ = X.shape[1]
 
         weights = _check_sample_weight(sample_weight, X, dtype=np.float64)
@@ -501,7 +531,13 @@ class GALNetwork(ClassifierMixin, BaseEstimator):
         else:
             X_val_t, y_val_t, w_val_t = X_t, y_t, w_t
 
-        model = self._build_model(self.n_features_in_, self.initial_hidden, n_classes).to(device)
+        # Continuing keeps the architecture the previous fit grew, not just its
+        # weights: restarting from initial_hidden would throw away the search.
+        model: nn.Sequential = (
+            self.model_
+            if continuing
+            else self._build_model(self.n_features_in_, self.initial_hidden, n_classes).to(device)
+        )
         optimizer = self._make_optimizer(model)
 
         generator = None

--- a/neural_trees/decision_trees/soft_decision_tree.py
+++ b/neural_trees/decision_trees/soft_decision_tree.py
@@ -267,6 +267,21 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         `"balanced"` uses `n_samples / (n_classes * bincount(y))`, which is what
         an imbalanced target usually needs: without it a rare class contributes
         so little to the loss that the tree can ignore it entirely.
+    warm_start : bool, default=False
+        When True, a second call to `fit` continues from the parameters the
+        first one left, instead of reinitializing. Useful for training in
+        stages, or for extending a run that turned out too short.
+
+        This is `warm_start` rather than `partial_fit` deliberately. sklearn's
+        `partial_fit` contract promises that a model updated on batches
+        approaches one trained on the union, and requires handling classes that
+        were absent from the first call. Neither holds here: the architecture
+        is fixed at the first fit, and mini-batch gradient descent over a second
+        dataset drifts toward that dataset rather than the union. `warm_start`
+        promises only what is actually delivered, which is continuation.
+
+        The label set must not change between calls; a new class would need an
+        output layer this model cannot grow.
     growth : {"none", "incremental"}, default="none"
         How the tree reaches its depth.
 
@@ -344,6 +359,7 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         random_state: Optional[int] = None,
         class_weight=None,
         growth: str = "none",
+        warm_start: bool = False,
         learn_temperature: bool = False,
         early_stopping: bool = False,
         validation_fraction: float = 0.1,
@@ -359,6 +375,7 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         self.random_state = random_state
         self.class_weight = class_weight
         self.growth = growth
+        self.warm_start = warm_start
         self.learn_temperature = learn_temperature
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
@@ -399,9 +416,11 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
 
         X, y = check_X_y(X, y)
         check_classification_targets(y)
-        self.le_ = LabelEncoder()
-        y_enc = self.le_.fit_transform(y)
-        self.classes_ = self.le_.classes_
+        encoder = LabelEncoder()
+        y_enc = encoder.fit_transform(y)
+        continuing = self._reuse_existing_model(len(encoder.classes_))
+        self.le_ = encoder
+        self.classes_ = encoder.classes_
         self.n_features_in_ = X.shape[1]
         n_classes = len(self.classes_)
 
@@ -460,16 +479,24 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
 
         self.training_history_: List[dict] = []
 
+        if self.growth_ == "incremental" and continuing:
+            raise ValueError(
+                "warm_start=True is not supported with growth='incremental': the "
+                "second fit would restart the search from a single split and "
+                "discard the depth the first one chose."
+            )
+
         if self.growth_ == "incremental":
             self._fit_incrementally(loader, X_val_t, y_val_t, n_classes, device)
         else:
-            self.model_ = _SoftTreeModule(
-                n_features=self.n_features_in_,
-                n_classes=n_classes,
-                depth=self.depth,
-                penalty_coef=self.penalty_coef,
-                learn_temperature=self.learn_temperature,
-            ).to(device)
+            if not continuing:
+                self.model_ = _SoftTreeModule(
+                    n_features=self.n_features_in_,
+                    n_classes=n_classes,
+                    depth=self.depth,
+                    penalty_coef=self.penalty_coef,
+                    learn_temperature=self.learn_temperature,
+                ).to(device)
             optimizer = torch.optim.Adam(self.model_.parameters(), lr=self.learning_rate)
             _, best_state = self._train_epochs(
                 self.model_, loader, optimizer, self.max_epochs, X_val_t, y_val_t,
@@ -482,6 +509,23 @@ class SoftDecisionTree(ClassifierMixin, BaseEstimator):
         self.n_iter_ = len(self.training_history_)
         self.feature_importances_ = self._compute_feature_importances(X_t)
         return self
+
+    def _reuse_existing_model(self, n_classes: int) -> bool:
+        """
+        Whether a previous fit's parameters can be continued from.
+
+        Refusing loudly when the label set changed is deliberate: silently
+        reinitializing would make warm_start look like it worked while throwing
+        away everything the first fit learned.
+        """
+        if not self.warm_start or not hasattr(self, "model_"):
+            return False
+        if len(getattr(self, "classes_", [])) != n_classes:
+            raise ValueError(
+                "warm_start=True requires the same classes across calls to fit; "
+                "the label set changed, and this model cannot grow its output layer."
+            )
+        return True
 
     def _can_hold_out(self, y_enc: np.ndarray) -> bool:
         """

--- a/neural_trees/mixture_of_experts/hierarchical_moe.py
+++ b/neural_trees/mixture_of_experts/hierarchical_moe.py
@@ -263,6 +263,21 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
     verbose : bool, default=False
     random_state : int or None, default=None
         Seed for weight initialization and shuffled mini-batches.
+    warm_start : bool, default=False
+        When True, a second call to `fit` continues from the parameters the
+        first one left, instead of reinitializing. Useful for training in
+        stages, or for extending a run that turned out too short.
+
+        This is `warm_start` rather than `partial_fit` deliberately. sklearn's
+        `partial_fit` contract promises that a model updated on batches
+        approaches one trained on the union, and requires handling classes that
+        were absent from the first call. Neither holds here: the architecture
+        is fixed at the first fit, and mini-batch gradient descent over a second
+        dataset drifts toward that dataset rather than the union. `warm_start`
+        promises only what is actually delivered, which is continuation.
+
+        The label set must not change between calls; a new class would need an
+        output layer this model cannot grow.
     class_weight : dict, "balanced" or None, default=None
         Weights per class, combined multiplicatively with `sample_weight`.
         `"balanced"` uses `n_samples / (n_classes * bincount(y))`. Without it a
@@ -299,6 +314,7 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         verbose: bool = False,
         random_state: Optional[int] = None,
         class_weight=None,
+        warm_start: bool = False,
     ):
         self.depth = depth
         self.branching_factor = branching_factor
@@ -313,6 +329,24 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         self.verbose = verbose
         self.random_state = random_state
         self.class_weight = class_weight
+        self.warm_start = warm_start
+
+    def _reuse_existing_model(self, n_classes: int) -> bool:
+        """
+        Whether a previous fit's parameters can be continued from.
+
+        Refusing loudly when the label set changed is deliberate: silently
+        reinitializing would make warm_start look like it worked while throwing
+        away everything the first fit learned.
+        """
+        if not self.warm_start or not hasattr(self, "model_"):
+            return False
+        if len(getattr(self, "classes_", [])) != n_classes:
+            raise ValueError(
+                "warm_start=True requires the same classes across calls to fit; "
+                "the label set changed, and this model cannot grow its output layer."
+            )
+        return True
 
     def fit(self, X, y, sample_weight=None) -> "HierarchicalMixtureOfExperts":
         if self.dropout_type not in ("subtree", "activation"):
@@ -324,9 +358,11 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         check_classification_targets(y)
         if self.random_state is not None:
             torch.manual_seed(self.random_state)
-        self.le_ = LabelEncoder()
-        y_enc = self.le_.fit_transform(y)
-        self.classes_ = self.le_.classes_
+        encoder = LabelEncoder()
+        y_enc = encoder.fit_transform(y)
+        continuing = self._reuse_existing_model(len(encoder.classes_))
+        self.le_ = encoder
+        self.classes_ = encoder.classes_
         self.n_features_in_ = X.shape[1]
 
         weights = _check_sample_weight(sample_weight, X, dtype=np.float64)
@@ -344,16 +380,17 @@ class HierarchicalMixtureOfExperts(ClassifierMixin, BaseEstimator):
         y_t = torch.LongTensor(y_enc).to(device)
         w_t = torch.FloatTensor(weights).to(device)
 
-        self.model_ = _HMoEModule(
-            n_features=self.n_features_in_,
-            n_classes=len(self.classes_),
-            depth=self.depth,
-            branching_factor=self.branching_factor,
-            gate_hidden=self.gate_hidden,
-            expert_hidden=self.expert_hidden,
-            dropout_rate=self.dropout_rate,
-            dropout_type=self.dropout_type,
-        ).to(device)
+        if not continuing:
+            self.model_ = _HMoEModule(
+                n_features=self.n_features_in_,
+                n_classes=len(self.classes_),
+                depth=self.depth,
+                branching_factor=self.branching_factor,
+                gate_hidden=self.gate_hidden,
+                expert_hidden=self.expert_hidden,
+                dropout_rate=self.dropout_rate,
+                dropout_type=self.dropout_type,
+            ).to(device)
 
         optimizer = torch.optim.Adam(self.model_.parameters(), lr=self.learning_rate)
         generator = None

--- a/tests/test_warm_start.py
+++ b/tests/test_warm_start.py
@@ -1,0 +1,104 @@
+"""
+warm_start continues a fit instead of restarting it.
+
+These tests cover the promise the parameter actually makes. It is deliberately
+not partial_fit: sklearn's contract there promises that batch updates approach
+training on the union, which mini-batch gradient descent over a second dataset
+does not deliver, and requires handling classes absent from the first call,
+which a fixed output layer cannot.
+"""
+import numpy as np
+import pytest
+from sklearn.datasets import load_wine
+from sklearn.preprocessing import StandardScaler
+
+from neural_trees import GALNetwork, HierarchicalMixtureOfExperts, SoftDecisionTree
+
+ESTIMATORS = [
+    lambda **kw: SoftDecisionTree(depth=3, random_state=0, **kw),
+    lambda **kw: HierarchicalMixtureOfExperts(depth=2, random_state=0, **kw),
+    lambda **kw: GALNetwork(random_state=0, **kw),
+]
+IDS = ["SoftDecisionTree", "HierarchicalMixtureOfExperts", "GALNetwork"]
+
+
+@pytest.fixture(scope="module")
+def wine():
+    X, y = load_wine(return_X_y=True)
+    return StandardScaler().fit_transform(X), y
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_second_fit_continues_instead_of_restarting(make_estimator, wine):
+    X, y = wine
+
+    warm = make_estimator(max_epochs=30, warm_start=True).fit(X, y)
+    after_first = warm.score(X, y)
+    warm.fit(X, y)
+    after_second = warm.score(X, y)
+
+    cold = make_estimator(max_epochs=30).fit(X, y)
+
+    assert after_second >= after_first
+    assert after_second >= cold.score(X, y)
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_without_warm_start_the_second_fit_starts_over(make_estimator, wine):
+    X, y = wine
+
+    estimator = make_estimator(max_epochs=20).fit(X, y)
+    first = estimator.predict_proba(X).copy()
+    estimator.fit(X, y)
+
+    # Same seed, same data, fresh initialization: identical, not continued.
+    np.testing.assert_allclose(first, estimator.predict_proba(X), rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_changing_the_label_set_is_refused(make_estimator, wine):
+    X, y = wine
+    estimator = make_estimator(max_epochs=5, warm_start=True).fit(X, y)
+
+    with pytest.raises(ValueError, match="same classes"):
+        estimator.fit(X, np.where(y == 2, 1, y))
+
+
+@pytest.mark.parametrize("make_estimator", ESTIMATORS, ids=IDS)
+def test_first_fit_with_warm_start_behaves_normally(make_estimator, wine):
+    """Nothing to continue from, so it must match an ordinary fit."""
+    X, y = wine
+
+    warm = make_estimator(max_epochs=20, warm_start=True).fit(X, y)
+    cold = make_estimator(max_epochs=20).fit(X, y)
+
+    np.testing.assert_allclose(
+        warm.predict_proba(X), cold.predict_proba(X), rtol=1e-5, atol=1e-6
+    )
+
+
+def test_gal_keeps_the_architecture_growth_chose(wine):
+    """Continuing must not restart the network from initial_hidden."""
+    X, y = wine
+
+    gal = GALNetwork(max_epochs=60, random_state=0, warm_start=True).fit(X, y)
+    grown_units = gal.n_hidden_final_
+    assert grown_units > gal.initial_hidden
+
+    gal.fit(X, y)
+    assert gal.n_hidden_final_ >= grown_units
+
+
+def test_incremental_growth_refuses_warm_start(wine):
+    """
+    The second fit would restart the depth search from a single split and throw
+    away the depth the first one chose, so it is refused rather than silently
+    doing that.
+    """
+    X, y = wine
+    sdt = SoftDecisionTree(
+        depth=3, max_epochs=30, growth="incremental", warm_start=True, random_state=0
+    ).fit(X, y)
+
+    with pytest.raises(ValueError, match="not supported with growth"):
+        sdt.fit(X, y)


### PR DESCRIPTION
The README's Limitations section said training is batch only and there is no `partial_fit`. #70 asked for one of `partial_fit` or `warm_start`, and to say why.

**`warm_start`**, on all three torch-backed estimators. A second `fit` continues from the parameters the first one left instead of reinitializing.

### Why not `partial_fit`

sklearn's `partial_fit` contract promises that a model updated on successive batches approaches one trained on their union, and requires handling classes absent from the first call. Neither holds here:

- the architecture is fixed at the first fit, so a class that was not there has no output unit to go to
- mini-batch gradient descent over a second dataset drifts toward *that* dataset, not toward the union

`warm_start` promises only what is delivered: continuation. Implementing `partial_fit` would have meant shipping a name whose contract the model does not honour, which is the kind of thing this library has spent several releases removing.

### Measured

Wine, scaled, same seed:

| | 60 epochs in one call | 30 + 30 with warm_start | 30 epochs cold |
|---|:---:|:---:|:---:|
| SoftDecisionTree | 1.000 | 1.000 | 0.994 |
| HierarchicalMixtureOfExperts | 0.994 | **1.000** | 0.983 |

### Refusals rather than surprises

- **A changed label set raises.** Silently reinitializing would make `warm_start` look like it worked while discarding everything the first fit learned.
- **`GALNetwork` keeps the architecture growth chose**, not just the weights. Restarting from `initial_hidden` would throw away the search that is the whole point of the model.
- **`growth="incremental"` refuses `warm_start`.** The second fit would restart the depth search from a single split and discard the depth the first one chose.

### On the estimator checks

`check_estimator` stays **62/63** on the defaults for all three, since `warm_start=False` is the default. With `warm_start=True` it is 61/63: `check_supervised_y_2d` fits twice on one estimator and requires identical predictions, which is precisely what continuing a fit is not. That is inherent to the parameter rather than a defect, and sklearn's own warm-startable estimators behave the same way.

Closes #70
