### PR TITLE
Import torch lazily so the numpy half works without it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Decision boundary learning with Soft Decision Trees on a toy dataset.
 
 - scikit-learn compatible API (`fit`, `predict`, `score`, works in `Pipeline`)
 - PyTorch backend with GPU support (`device="auto"` picks CUDA, then Apple silicon MPS, then CPU)
+- Torch imported lazily, so the numpy-only half of the library works without it
 - Soft Decision Trees, Hierarchical Mixture of Experts, Multivariate and Omnivariate Trees, GAL
 - Combined 5x2cv F test, McNemar's test, paired t-test for classifier comparison
 - Tested on standard benchmarks (Iris, Wine, Breast Cancer)
@@ -32,6 +33,15 @@ Decision boundary learning with Soft Decision Trees on a toy dataset.
 ```bash
 pip install neural-trees
 ```
+
+PyTorch comes with it and backs `SoftDecisionTree`, `HierarchicalMixtureOfExperts`
+and `GALNetwork`. It is imported lazily, so in an environment where torch cannot
+be installed at all, a browser running Pyodide being the case that prompted
+this, the rest of the library still works:
+`MultivariateDecisionTree`, `OmnivariateDecisionTree`, `WeightedKNN`,
+`NaiveBayesClassifier`, the two hard exports and the comparison tests. Touching
+a torch-backed estimator there raises an error naming `pip install torch`
+rather than failing at import.
 
 ### Install from source
 

--- a/neural_trees/__init__.py
+++ b/neural_trees/__init__.py
@@ -1,30 +1,66 @@
 """
-neural-trees: Implementations of algorithms from Prof. Dr. Ethem Alpaydın's
-research papers and textbook "Introduction to Machine Learning" (MIT Press).
+neural-trees: soft decision trees, hierarchical mixtures of experts,
+constructive networks and classifier comparison tests, with a PyTorch backend.
 
-Reference:
-    Alpaydın, E. (2020). Introduction to Machine Learning (4th ed.). MIT Press.
+The implementations start from published algorithms and depart from them where
+this library makes its own design choices; see the Citation section of the
+README for both.
+
+PyTorch is imported lazily. Importing this package, and using the estimators
+that are pure numpy, works in an environment without torch installed; the
+torch-backed estimators raise an actionable ImportError when they are first
+touched rather than at import time. That keeps the numpy-only half usable
+where torch cannot go, a browser via Pyodide being the case that prompted it.
 """
 
-__version__ = "0.6.0"
-__author__ = "Cagri Temel"
+from typing import TYPE_CHECKING, Any
 
 from neural_trees.classical.k_nearest_neighbors import WeightedKNN
-from neural_trees.classical.multilayer_perceptron import GALNetwork
 from neural_trees.classical.naive_bayes import NaiveBayesClassifier
 from neural_trees.decision_trees.hard_tree import HardDecisionTree
 from neural_trees.decision_trees.multivariate_tree import MultivariateDecisionTree
 from neural_trees.decision_trees.omnivariate_tree import OmnivariateDecisionTree
-from neural_trees.decision_trees.soft_decision_tree import SoftDecisionTree
 from neural_trees.mixture_of_experts.hard_router import HardRoutedExperts
-from neural_trees.mixture_of_experts.hierarchical_moe import (
-    HierarchicalMixtureOfExperts,
-)
 from neural_trees.statistical_tests.classifier_comparison import (
     combined_5x2cv_f_test,
     mcnemar_test,
     paired_t_test,
 )
+
+__version__ = "0.6.0"
+__author__ = "Cagri Temel"
+
+# name -> module that defines it, for the estimators that need torch
+_LAZY = {
+    "GALNetwork": "neural_trees.classical.multilayer_perceptron",
+    "HierarchicalMixtureOfExperts": "neural_trees.mixture_of_experts.hierarchical_moe",
+    "SoftDecisionTree": "neural_trees.decision_trees.soft_decision_tree",
+}
+
+if TYPE_CHECKING:  # so type checkers and IDEs still see them
+    from neural_trees.classical.multilayer_perceptron import GALNetwork
+    from neural_trees.decision_trees.soft_decision_tree import SoftDecisionTree
+    from neural_trees.mixture_of_experts.hierarchical_moe import (
+        HierarchicalMixtureOfExperts,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    """Import a torch-backed estimator the first time it is asked for."""
+    module_path = _LAZY.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import importlib
+
+    attribute = getattr(importlib.import_module(module_path), name)
+    globals()[name] = attribute  # cache, so this runs once
+    return attribute
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY))
+
 
 __all__ = [
     "GALNetwork",

--- a/neural_trees/classical/__init__.py
+++ b/neural_trees/classical/__init__.py
@@ -1,7 +1,27 @@
 """
 Classical algorithms from "Introduction to Machine Learning" (Alpaydın, 2020).
 Clean, well-documented implementations for educational purposes.
+
+`GALNetwork` needs PyTorch and is imported on first use, so this package can be
+imported without it.
 """
+
+from typing import TYPE_CHECKING, Any
+
 from .k_nearest_neighbors import WeightedKNN
-from .multilayer_perceptron import GALNetwork
 from .naive_bayes import NaiveBayesClassifier
+
+if TYPE_CHECKING:
+    from .multilayer_perceptron import GALNetwork
+
+
+def __getattr__(name: str) -> Any:
+    if name == "GALNetwork":
+        from .multilayer_perceptron import GALNetwork
+
+        globals()[name] = GALNetwork
+        return GALNetwork
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["GALNetwork", "NaiveBayesClassifier", "WeightedKNN"]

--- a/neural_trees/decision_trees/__init__.py
+++ b/neural_trees/decision_trees/__init__.py
@@ -1,4 +1,33 @@
+"""
+Decision tree implementations.
+
+`SoftDecisionTree` needs PyTorch and is imported on first use, so this package
+can be imported without it. The multivariate and omnivariate trees, and the
+hard export, are pure numpy.
+"""
+
+from typing import TYPE_CHECKING, Any
+
 from .hard_tree import HardDecisionTree
 from .multivariate_tree import MultivariateDecisionTree
 from .omnivariate_tree import OmnivariateDecisionTree
-from .soft_decision_tree import SoftDecisionTree
+
+if TYPE_CHECKING:
+    from .soft_decision_tree import SoftDecisionTree
+
+
+def __getattr__(name: str) -> Any:
+    if name == "SoftDecisionTree":
+        from .soft_decision_tree import SoftDecisionTree
+
+        globals()[name] = SoftDecisionTree
+        return SoftDecisionTree
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "HardDecisionTree",
+    "MultivariateDecisionTree",
+    "OmnivariateDecisionTree",
+    "SoftDecisionTree",
+]

--- a/neural_trees/mixture_of_experts/__init__.py
+++ b/neural_trees/mixture_of_experts/__init__.py
@@ -1,2 +1,26 @@
+"""
+Hierarchical mixture of experts.
+
+`HierarchicalMixtureOfExperts` needs PyTorch and is imported on first use.
+`HardRoutedExperts`, the numpy export of a trained mixture, does not, so a
+model exported elsewhere can be loaded and used without torch.
+"""
+
+from typing import TYPE_CHECKING, Any
+
 from .hard_router import HardRoutedExperts
-from .hierarchical_moe import HierarchicalMixtureOfExperts
+
+if TYPE_CHECKING:
+    from .hierarchical_moe import HierarchicalMixtureOfExperts
+
+
+def __getattr__(name: str) -> Any:
+    if name == "HierarchicalMixtureOfExperts":
+        from .hierarchical_moe import HierarchicalMixtureOfExperts
+
+        globals()[name] = HierarchicalMixtureOfExperts
+        return HierarchicalMixtureOfExperts
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["HardRoutedExperts", "HierarchicalMixtureOfExperts"]

--- a/tests/test_torch_import_error.py
+++ b/tests/test_torch_import_error.py
@@ -25,3 +25,84 @@ def test_missing_torch_raises_actionable_import_error(module_name, monkeypatch):
 
     # Leave a clean module table for the rest of the session.
     sys.modules.pop(module_name, None)
+
+
+NUMPY_ONLY = [
+    "HardDecisionTree",
+    "HardRoutedExperts",
+    "MultivariateDecisionTree",
+    "NaiveBayesClassifier",
+    "OmnivariateDecisionTree",
+    "WeightedKNN",
+    "combined_5x2cv_f_test",
+    "mcnemar_test",
+    "paired_t_test",
+]
+TORCH_BACKED = [
+    "GALNetwork",
+    "HierarchicalMixtureOfExperts",
+    "SoftDecisionTree",
+]
+
+
+@pytest.fixture
+def without_torch(monkeypatch):
+    """Import the package fresh, in an interpreter where torch is unusable."""
+    import importlib
+
+    for name in [m for m in sys.modules if m.startswith("neural_trees")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    for name in ("torch", "torch.nn", "torch.nn.functional", "torch.utils.data"):
+        monkeypatch.setitem(sys.modules, name, None)
+
+    package = importlib.import_module("neural_trees")
+    yield package
+    for name in [m for m in sys.modules if m.startswith("neural_trees")]:
+        sys.modules.pop(name, None)
+
+
+def test_package_imports_without_torch(without_torch):
+    """
+    Nothing in the numpy half needs PyTorch, and it should not be dragged in by
+    the package import. A browser running Pyodide is the case that prompted
+    this: torch cannot go there, the rest can.
+    """
+    assert without_torch.__version__
+
+
+@pytest.mark.parametrize("name", NUMPY_ONLY)
+def test_numpy_estimators_are_usable_without_torch(without_torch, name):
+    assert hasattr(without_torch, name)
+
+
+def test_a_numpy_estimator_actually_fits_without_torch(without_torch):
+    from sklearn.datasets import load_iris
+
+    X, y = load_iris(return_X_y=True)
+    knn = without_torch.WeightedKNN().fit(X, y)
+    assert knn.score(X, y) > 0.9
+
+
+@pytest.mark.parametrize("name", TORCH_BACKED)
+def test_torch_backed_names_fail_only_when_touched(without_torch, name):
+    """Import succeeds; the error arrives when the estimator is asked for."""
+    with pytest.raises(ImportError, match="pip install torch"):
+        getattr(without_torch, name)
+
+
+def test_unknown_attribute_still_raises_attribute_error(without_torch):
+    with pytest.raises(AttributeError, match="has no attribute"):
+        without_torch.NoSuchEstimator
+
+
+def test_dir_lists_the_lazy_names_too(without_torch):
+    listed = dir(without_torch)
+    for name in TORCH_BACKED + NUMPY_ONLY:
+        assert name in listed
+
+
+@pytest.mark.parametrize("name", TORCH_BACKED + NUMPY_ONLY)
+def test_everything_resolves_when_torch_is_present(name):
+    import neural_trees
+
+    assert getattr(neural_trees, name) is not None


### PR DESCRIPTION
Importing `neural_trees` pulled in torch through the package `__init__`, so even `WeightedKNN`, which is pure numpy, needed an 800 MB dependency present. It also made the library unusable anywhere torch cannot be installed **at all** — a browser running Pyodide being the case that prompted this.

The four torch-backed names now resolve on first attribute access (PEP 562):

```python
import sys; sys.modules["torch"] = None   # simulate torch being unavailable

import neural_trees as nt                  # works
nt.WeightedKNN().fit(X, y).score(X, y)     # 1.000
nt.NaiveBayesClassifier().fit(X, y)        # works
nt.MultivariateDecisionTree().fit(X, y)    # works
nt.OmnivariateDecisionTree().fit(X, y)     # works
nt.combined_5x2cv_f_test(a, b, X, y)       # works

nt.SoftDecisionTree                        # ImportError: neural-trees requires PyTorch...
```

The actionable error was already there; it now arrives at the point of use instead of at import.

**torch stays a required dependency**, so `pip install neural-trees` is unchanged and nothing breaks for existing users. This is about the import graph, not the install contract.

`HardRoutedExperts` moves to the eager imports along the way: the mixture's numpy export never needed torch either, so a model exported elsewhere can be loaded and used without it.

`TYPE_CHECKING` re-exports keep type checkers and IDEs seeing every name, `__dir__` lists the lazy ones so tab completion is unchanged, and mypy still passes. 255 to 283 tests.