### PR TITLE
Make requirements.txt the playground's deploy manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,13 @@ side on standard and synthetic datasets, with live decision boundaries and
 hyperparameter controls:
 
 ```bash
-pip install streamlit plotly
+pip install -r requirements.txt
 streamlit run app.py
 ```
+
+The same file is what [Streamlit Community
+Cloud](https://streamlit.io/cloud) installs, so the hosted version and the
+local one run the same code.
 
 ## Benchmark
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
-numpy>=1.21
-scipy>=1.7
-scikit-learn>=1.0
-torch>=1.10
-matplotlib>=3.4
-jupyter
-pytest>=7.0
-pytest-cov
-plotly
-streamlit>=1.30.0
+# What the Streamlit playground (app.py) needs at runtime. Streamlit Community
+# Cloud installs this file; the library's own dependencies are declared in
+# pyproject.toml and its development tooling in requirements-dev.txt.
+#
+# CPU-only torch. The default PyPI wheel bundles CUDA and runs to roughly
+# 2.5 GB, which does not fit a free tier and would never be used there anyway.
+# The +cpu wheels carry a higher local version than the plain ones, so pip
+# prefers them when this index is available.
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+neural-trees==0.6.0
+streamlit>=1.30
+plotly>=5.0


### PR DESCRIPTION
Since packaging moved to `pyproject.toml`, `requirements.txt` had become a leftover: it listed the library's dependencies **plus** jupyter, pytest and matplotlib, and nothing read it. Streamlit Community Cloud does read it, so it now says what the playground needs and nothing else.

```
--extra-index-url https://download.pytorch.org/whl/cpu

neural-trees==0.6.0
streamlit>=1.30
plotly>=5.0
```

**Why the extra index.** The default PyPI torch wheel bundles CUDA and runs to roughly 2.5 GB on Linux, which a free tier will not carry and this app would never use. The `+cpu` wheels carry a higher local version than the plain ones, so pip prefers them where they exist, and falls back cleanly on macOS, where PyPI's torch is already CPU-only.

**Verified end to end** on Python 3.12 with exactly this file: the install resolves, and `streamlit run app.py` answers 200 on `/_stcore/health`.

One caveat I could not test from here: whether the `+cpu` preference actually fires on Linux. On macOS there are no `+cpu` wheels to prefer, so the mechanism is untested on the platform where it matters. If a Cloud build fails on size, the fallback is an explicit `torch==X.Y.Z+cpu` pin, at the cost of breaking `pip install -r requirements.txt` for macOS developers.

(Unrelated, but worth noting for anyone reproducing locally: the interpreter on this machine is 3.9.7, which streamlit excludes **by name** as a known-bad CPython release, so the install fails there for reasons that have nothing to do with this file.)