### PR TITLE
Make the live demo findable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Soft decision trees, mixture of experts, and statistical model comparison tests 
 Decision boundary learning with Soft Decision Trees on a toy dataset.
 </p>
 
+[![Live demo](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://neural-trees.streamlit.app)
 [![PyPI](https://img.shields.io/pypi/v/neural-trees)](https://pypi.org/project/neural-trees/)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/neural-trees?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/neural-trees)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
@@ -27,6 +28,10 @@ Decision boundary learning with Soft Decision Trees on a toy dataset.
 - Soft Decision Trees, Hierarchical Mixture of Experts, Multivariate and Omnivariate Trees, GAL
 - Combined 5x2cv F test, McNemar's test, paired t-test for classifier comparison
 - Tested on standard benchmarks (Iris, Wine, Breast Cancer)
+
+**[Try it in the browser](https://neural-trees.streamlit.app)** — every model
+in this library against CART, Random Forest and SVM, with live decision
+boundaries and a hypothesis test instead of an eyeballed accuracy difference.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
 ]
 
 [project.urls]
+"Live demo" = "https://neural-trees.streamlit.app"
 Source = "https://github.com/cgrtml/neural-trees"
 "Bug Tracker" = "https://github.com/cgrtml/neural-trees/issues"
 Documentation = "https://github.com/cgrtml/neural-trees#readme"


### PR DESCRIPTION
The playground was mentioned **once**, on line 106, in the middle of the README. No badge, and nothing in the PyPI project links. Someone arriving from PyPI or the GitHub landing page had no way to reach it.

- A **Live demo** badge at the top, next to the PyPI and CI badges
- A line under the badges saying what it is: every model in the library against CART, Random Forest and SVM, with live boundaries and a hypothesis test instead of an eyeballed accuracy difference
- A `Live demo` entry in `[project.urls]`, so it shows in PyPI's sidebar

This is the cheap version of the reach a hosted demo is meant to buy, and it costs nothing per month.