### PR TITLE
Add a documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+          pip install -e . --extra-index-url https://download.pytorch.org/whl/cpu
+
+      - name: Build
+        # -W turns warnings into errors: the docs must not rot silently.
+        run: sphinx-build -b html -W --keep-going docs docs/_build/html
+
+      - name: Upload
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ paper/arxiv/*.pdf
 paper/arxiv/*.aux
 paper/arxiv/*.log
 paper/arxiv/*.out
+
+# Sphinx build artefacts
+docs/_build/
+docs/auto_examples/
+docs/generated/
+docs/sg_execution_times.rst

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Decision boundary learning with Soft Decision Trees on a toy dataset.
 
 [![Live demo](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://neural-trees.streamlit.app)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22718897.svg)](https://doi.org/10.5281/zenodo.22718897)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://cagritemel.com/neural-trees/)
 [![PyPI](https://img.shields.io/pypi/v/neural-trees)](https://pypi.org/project/neural-trees/)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/neural-trees?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/neural-trees)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,8 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,45 @@
+API reference
+=============
+
+Decision trees
+--------------
+
+.. autosummary::
+   :toctree: generated
+   :template: autosummary/class.rst
+
+   neural_trees.SoftDecisionTree
+   neural_trees.MultivariateDecisionTree
+   neural_trees.OmnivariateDecisionTree
+   neural_trees.HardDecisionTree
+
+Mixtures of experts
+-------------------
+
+.. autosummary::
+   :toctree: generated
+   :template: autosummary/class.rst
+
+   neural_trees.HierarchicalMixtureOfExperts
+   neural_trees.HardRoutedExperts
+
+Constructive and classical models
+---------------------------------
+
+.. autosummary::
+   :toctree: generated
+   :template: autosummary/class.rst
+
+   neural_trees.GALNetwork
+   neural_trees.WeightedKNN
+   neural_trees.NaiveBayesClassifier
+
+Statistical tests
+-----------------
+
+.. autosummary::
+   :toctree: generated
+
+   neural_trees.combined_5x2cv_f_test
+   neural_trees.mcnemar_test
+   neural_trees.paired_t_test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,2 @@
+```{include} ../CHANGELOG.md
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,69 @@
+"""Sphinx configuration for the neural-trees documentation."""
+
+import os
+import sys
+from datetime import date
+
+sys.path.insert(0, os.path.abspath(".."))
+
+import neural_trees  # noqa: E402
+
+project = "neural-trees"
+author = "Cagri Temel"
+copyright = f"{date.today().year}, {author}"
+version = neural_trees.__version__
+release = version
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.mathjax",
+    "numpydoc",
+    "sphinx_gallery.gen_gallery",
+    "myst_parser",
+]
+
+autosummary_generate = True
+autodoc_default_options = {"members": True, "inherited-members": False}
+numpydoc_show_class_members = False
+numpydoc_class_members_toctree = False
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "sklearn": ("https://scikit-learn.org/stable", None),
+    "torch": ("https://docs.pytorch.org/docs/stable", None),
+}
+
+sphinx_gallery_conf = {
+    "examples_dirs": "../examples",
+    "gallery_dirs": "auto_examples",
+    "filename_pattern": r"\.py",
+    "ignore_pattern": r"__init__\.py",
+    "remove_config_comments": True,
+    "download_all_examples": False,
+    "plot_gallery": "True",
+}
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
+
+html_theme = "pydata_sphinx_theme"
+html_title = f"neural-trees {version}"
+html_static_path = ["_static"]
+html_theme_options = {
+    "github_url": "https://github.com/cgrtml/neural-trees",
+    "icon_links": [
+        {
+            "name": "PyPI",
+            "url": "https://pypi.org/project/neural-trees/",
+            "icon": "fa-brands fa-python",
+        },
+    ],
+    "show_prev_next": False,
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
+}
+html_context = {"default_mode": "auto"}

--- a/docs/design_decisions.rst
+++ b/docs/design_decisions.rst
@@ -1,0 +1,177 @@
+Design decisions
+================
+
+The implementations begin from published algorithms and depart from them where
+measurement justified it. This page records the departures and the numbers
+behind them, so that a reader can disagree with a choice on the evidence rather
+than on taste. Every figure below comes from running the code: three seeds of
+stratified five-fold cross-validation, features standardised on the training
+fold only, both arms of each comparison sharing seeds and folds.
+
+Growth must not preserve the function exactly
+---------------------------------------------
+
+Deepening a soft tree looks like it should be done without disturbing what the
+tree has learned. Turn every leaf into a gate with all-zero parameters, so it
+sends half the arriving mass each way, and give both children the parent's class
+distribution. The mixture is unchanged and the extra capacity is available.
+
+This does not work, and the reason is exact rather than statistical. With
+:math:`Q_L = Q_R` the subtree's output does not depend on the gate at all, so
+
+.. math::
+
+   \frac{\partial}{\partial g}\left( g\,Q_R + (1-g)\,Q_L \right) = Q_R - Q_L = 0,
+
+and the gate's gradient is identically zero. With the gate at :math:`g = 1/2`
+the two children receive identical gradients, so they stay identical, so the
+gate's gradient stays zero. The state reproduces itself at every step: it is a
+fixed point of the optimiser, not a slow start. The added level is dead weight
+while costing full parameters and compute.
+
+Perturbing the child distributions slightly at insertion breaks the symmetry.
+The function is then preserved only approximately, which is the price of the
+level being able to learn anything.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 30 30
+
+   * - Growth
+     - Iris
+     - Wine
+   * - Exactly function-preserving
+     - 0.753
+     - 0.754
+   * - Perturbed by 0.05
+     - 0.942
+     - 0.979
+   * - Perturbed by 0.2 (the default)
+     - 0.942
+     - 0.979
+   * - Perturbed by 0.5
+     - 0.938
+     - 0.981
+   * - Same depth, trained from scratch
+     - 0.958
+     - 0.977
+
+The perturbation needs to be nonzero and otherwise needs no tuning: a tenfold
+change in it moves accuracy by four tenths of a point on Iris and two tenths on
+Wine, while setting it to zero costs about twenty. A regression test asserts
+that the zero gradient exists when the symmetry is not broken.
+
+New units should be fitted to the residual
+------------------------------------------
+
+The GAL network installs a new hidden unit with random weights. Such a unit
+perturbs every output logit the moment it arrives, damaging a network that was
+just judged to have stopped improving, and then has to be trained from noise.
+
+``growth_init="residual"`` freezes the network, trains the candidate unit to
+correlate with the residual error, and installs it with zero outgoing weights.
+That is safe here — unlike the tree case above — because the outgoing weights
+have a nonzero gradient as soon as the incoming weights are informative.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 30 30
+
+   * - New-unit initialisation
+     - Accuracy
+     - Hidden units
+   * - ``"random"``
+     - 0.938
+     - 17.4
+   * - ``"residual"``
+     - 0.956
+     - 6.6
+
+The size difference is the more interesting half. Random units arrive unhelpful,
+the error does not fall, and the growth criterion fires again, so the network
+grows *because* growth is not working.
+
+Node-level significance does not compose
+----------------------------------------
+
+The omnivariate tree picks each node's split type by cross-validated accuracy,
+which prefers a nonlinear split for any improvement at all, however small.
+Demanding statistical significance instead sounds strictly better: simpler nodes
+at little cost.
+
+Measured on Breast Cancer at maximum depth 3, it is worse on both axes.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 16 14 14 14 16
+
+   * - ``selection``
+     - Accuracy
+     - Nodes
+     - Univariate
+     - Linear
+     - Nonlinear
+   * - ``"accuracy"``
+     - 0.971
+     - 4.1
+     - 8
+     - 0
+     - 15
+   * - ``"test"``
+     - 0.960
+     - 7.3
+     - 20
+     - 14
+     - 13
+
+Per node the rule does exactly what it was asked to do: nonlinear splits fall
+from 15 to 13 and univariate splits rise from 8 to 20. But a simpler split
+separates its node's data less cleanly, so its children inherit harder problems
+and must themselves be split, and the tree grows from 4.1 nodes to 7.3 while
+losing a point of accuracy. Parsimony enforced locally is paid for globally.
+
+On Iris and Wine the rule never fires, because the test needs a minimum sample
+count per node and almost every node below the root falls under it. A
+significance criterion is unavailable exactly where a recursive method does most
+of its work, since nodes get smaller with depth by construction.
+
+This is why ``selection="test"`` is opt-in rather than the default.
+
+The hard export reports its agreement
+-------------------------------------
+
+``to_hard_tree()`` could present itself as a faithful re-encoding of the soft
+model. It is not one: a mixture over leaves is not a single path, and reading
+each gate as a hard decision discards the mixing. Over fifteen folds on Wine the
+export agreed with its source model on 0.998 of held-out samples on average,
+with 0.971 in the worst fold, and predicted about four times faster. The method
+reports that agreement rather than assuming it.
+
+Four models that did not work
+-----------------------------
+
+An early release shipped four models that were broken, and none of them
+announced it. They were found by writing tests, not by reading code.
+
+:class:`~neural_trees.HierarchicalMixtureOfExperts`
+  Could not take a single gradient step. Child weights were written in place
+  into one preallocated tensor, which autograd had saved for the multiplication
+  backward, so every call to ``backward()`` raised.
+
+:class:`~neural_trees.OmnivariateDecisionTree`
+  Computed its node classifier's decision, discarded it, and always descended
+  right. Every sample reached the same leaf; five-fold accuracy at depth three
+  was 0.000 on Iris.
+
+:class:`~neural_trees.GALNetwork`
+  Took one full-batch gradient step per epoch, so growth and pruning decisions
+  were made on a network that had barely moved from its initialisation. It
+  scored 0.333 on three well-separated blobs, which is chance for three classes.
+
+:class:`~neural_trees.WeightedKNN`
+  Condensed nearest neighbour made a single pass over the training set, leaving
+  a prototype store that did not classify that set correctly.
+
+The test suite now has 283 tests at 95% coverage, gated in CI, and every
+estimator is checked against
+:func:`sklearn.utils.estimator_checks.check_estimator`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,79 @@
+neural-trees
+============
+
+Differentiable and constructive classifiers with a scikit-learn API and a
+PyTorch backend: soft decision trees, multivariate and omnivariate trees,
+hierarchical mixtures of experts, a grow-and-prune network, and the statistical
+tests used to decide whether one classifier is genuinely better than another.
+
+Every model is an ordinary estimator, so it composes with
+:class:`~sklearn.pipeline.Pipeline`, :class:`~sklearn.model_selection.GridSearchCV`
+and the rest of the ecosystem.
+
+.. code-block:: python
+
+   from sklearn.datasets import load_wine
+   from sklearn.model_selection import cross_val_score
+   from sklearn.pipeline import make_pipeline
+   from sklearn.preprocessing import StandardScaler
+
+   from neural_trees import SoftDecisionTree
+
+   X, y = load_wine(return_X_y=True)
+   model = make_pipeline(StandardScaler(), SoftDecisionTree(depth=4, random_state=0))
+   print(cross_val_score(model, X, y, cv=5).mean())
+
+Install with ``pip install neural-trees``.
+
+Why this library exists
+-----------------------
+
+Soft decision trees, omnivariate trees and hierarchical mixtures of experts are
+standard material in machine learning courses and are cited regularly, but
+working implementations with a familiar API are scarce. A practitioner who
+wants to compare a soft tree against CART on their own data usually has to
+reimplement the model from the paper, and the reimplementation is then
+unverified.
+
+The second reason is honest comparison. The package ships Alpaydın's combined
+5x2cv F test alongside McNemar's test and the paired t-test, because an accuracy
+difference on one split says little until you know how much that number moves
+when only the fold assignment changes.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Getting started
+
+   install
+   user_guide
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   model_comparison
+   design_decisions
+   api
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Examples
+
+   auto_examples/index
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Project
+
+   changelog
+
+Citing
+------
+
+The software is archived on Zenodo. The concept DOI
+`10.5281/zenodo.22718897 <https://doi.org/10.5281/zenodo.22718897>`_ always
+resolves to the most recent release; cite the DOI of the specific version you
+ran when the version matters.
+
+When you use one of the underlying methods, cite the paper it comes from as
+well. Each is listed in :doc:`user_guide`.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,52 @@
+Installation
+============
+
+.. code-block:: bash
+
+   pip install neural-trees
+
+Requirements
+------------
+
+Python 3.9 to 3.13. The package depends on NumPy, scikit-learn and PyTorch.
+
+PyTorch is imported lazily: ``import neural_trees`` does not pull it in, and the
+classical estimators (:class:`~neural_trees.WeightedKNN`,
+:class:`~neural_trees.NaiveBayesClassifier`) run without it. The differentiable
+models raise a clear error if torch is missing rather than failing at fit time.
+
+CPU-only installation
+---------------------
+
+The default PyTorch wheel is large because it carries CUDA. For a CPU-only
+environment:
+
+.. code-block:: bash
+
+   pip install neural-trees --extra-index-url https://download.pytorch.org/whl/cpu
+
+Device selection
+----------------
+
+Every differentiable estimator takes a ``device`` argument, defaulting to
+``"cpu"``. Pass ``device="auto"`` to pick CUDA when it is available, then Apple
+silicon's MPS, then CPU. Anything else is handed to torch as given, so
+``"cuda:1"`` works. The choice is resolved once in ``fit`` and recorded as
+``device_``, so prediction always runs where training did.
+
+:class:`~neural_trees.HierarchicalMixtureOfExperts` and
+:class:`~neural_trees.GALNetwork` additionally keep a float64 copy of the fitted
+model on the CPU and predict from it, so that the same input gives the same
+output across machines. This costs a little speed and buys reproducibility:
+float32 matrix products are sensitive to row order and to the BLAS
+implementation, which is enough to flip a prediction near a decision boundary.
+
+From source
+-----------
+
+.. code-block:: bash
+
+   git clone https://github.com/cgrtml/neural-trees
+   cd neural-trees
+   pip install -e ".[dev]"
+   pytest

--- a/docs/model_comparison.rst
+++ b/docs/model_comparison.rst
@@ -1,0 +1,73 @@
+Comparing classifiers
+=====================
+
+An accuracy difference on a single train/test split says very little. Split the
+data differently and the ordering can reverse. The package ships three tests for
+deciding whether a difference is real, in ``neural_trees``:
+
+.. code-block:: python
+
+   from neural_trees import combined_5x2cv_f_test, mcnemar_test, paired_t_test
+
+Combined 5x2cv F test
+---------------------
+
+The default choice when comparing two learning *algorithms* on one dataset. It
+runs five replications of two-fold cross-validation, giving ten accuracy
+differences, and combines them into an F statistic. It is designed to have a
+Type I error close to the nominal level, which the naive paired t-test over
+k-fold splits does not, because those splits share training data and the
+differences are not independent.
+
+.. code-block:: python
+
+   from sklearn.tree import DecisionTreeClassifier
+   from neural_trees import SoftDecisionTree, combined_5x2cv_f_test
+
+   statistic, p_value = combined_5x2cv_f_test(
+       SoftDecisionTree(depth=4, random_state=0),
+       DecisionTreeClassifier(random_state=0),
+       X, y, random_state=0,
+   )
+
+*Reference:* Alpaydın, E. (1999). Combined 5x2cv F test for comparing supervised
+classification learning algorithms. *Neural Computation*, 11(8), 1885–1892.
+
+McNemar's test
+--------------
+
+For comparing two *fitted* classifiers on one held-out set. It looks only at the
+samples the two models disagree on and asks whether the disagreement is
+lopsided. Use it when refitting is expensive or when the models are given.
+
+.. code-block:: python
+
+   statistic, p_value = mcnemar_test(y_true, y_pred_a, y_pred_b)
+
+Paired t-test
+-------------
+
+Included for completeness and for comparison with the other two. It is the test
+most often reached for and the one most likely to overstate significance on
+cross-validation folds, for the reason given above. Prefer the 5x2cv F test when
+you can afford the ten fits.
+
+Choosing between them
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Situation
+     - Test
+     - Why
+   * - Two algorithms, one dataset, refitting affordable
+     - ``combined_5x2cv_f_test``
+     - Calibrated Type I error
+   * - Two already-fitted models, one test set
+     - ``mcnemar_test``
+     - No refitting required
+   * - Repeated measurements you know to be independent
+     - ``paired_t_test``
+     - Assumptions actually hold

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+sphinx>=7.0
+pydata-sphinx-theme>=0.15
+numpydoc>=1.6
+sphinx-gallery>=0.15
+myst-parser>=2.0
+matplotlib>=3.4

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -1,0 +1,174 @@
+User guide
+==========
+
+The library has three groups of estimators and one group of statistical tests.
+All estimators follow the scikit-learn contract: ``fit``, ``predict``,
+``predict_proba``, ``score``, ``get_params``/``set_params``, and attributes with
+a trailing underscore that only exist after fitting.
+
+Soft decision trees
+-------------------
+
+A hard decision tree sends each sample down exactly one path. A soft decision
+tree replaces the threshold at each internal node with a sigmoid gate
+
+.. math::
+
+   g_n(x) = \sigma(w_n^\top x + b_n),
+
+so a sample reaches *every* leaf with some probability, and the output is the
+mixture of the leaf distributions weighted by those probabilities. The tree is
+then differentiable end to end and is trained by gradient descent.
+
+.. code-block:: python
+
+   from neural_trees import SoftDecisionTree
+
+   model = SoftDecisionTree(depth=4, max_epochs=100, random_state=0)
+   model.fit(X_train, y_train)
+
+Two consequences are worth knowing. Because :math:`w_n` is a vector, each split
+is oblique rather than axis-aligned, which is often what makes a shallow soft
+tree competitive with a much deeper CART. And because the model is a mixture,
+``feature_importances_`` is computed from the gate weights rather than from
+impurity decrease.
+
+Growing the tree
+^^^^^^^^^^^^^^^^
+
+``depth`` fixes the size of a complete tree. The ``growth`` argument builds one
+instead:
+
+``growth="none"``
+  Train a complete tree of the given depth. The default.
+
+``growth="incremental"``
+  Start shallow and add a level at a time, training between additions.
+
+``growth="per_leaf"``
+  Split one leaf at a time, choosing the leaf carrying the most expected error,
+  which is the rule of İrsoy, Yıldız and Alpaydın. ``depth`` becomes an upper
+  bound rather than a target, and the resulting tree is unbalanced.
+
+Per-leaf growth is usually the one to reach for when the tree should stay small
+and readable. On a synthetic problem with 800 samples and 20 features it reached
+0.885 with 3.7 splits on average, against 0.832 for a complete depth-6 tree
+using all 63.
+
+Reading the tree back out
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``to_hard_tree()`` reads each gate as a hard decision and returns a plain NumPy
+model that prints its rules and predicts faster.
+
+.. code-block:: python
+
+   hard = model.to_hard_tree()
+   print(hard.export_text(feature_names=feature_names))
+
+The export is an approximation, not a re-encoding: a mixture over leaves is not
+a single path, so the hard tree does not always agree with the model it came
+from. It reports its agreement rather than assuming it. Over fifteen folds on
+Wine the mean agreement was 0.998, with 0.971 in the worst fold, and prediction
+was about four times faster.
+
+*Reference:* İrsoy, O., Yıldız, O. T. and Alpaydın, E. (2012). Soft Decision
+Trees. *ICPR*, 1819–1822.
+
+Multivariate and omnivariate trees
+----------------------------------
+
+:class:`~neural_trees.MultivariateDecisionTree` splits on a linear combination
+of features at every node.
+
+:class:`~neural_trees.OmnivariateDecisionTree` chooses, at each node
+independently, between a univariate threshold, a linear split and a nonlinear
+split, so that simple regions of the space get simple splits.
+
+.. code-block:: python
+
+   from neural_trees import OmnivariateDecisionTree
+
+   tree = OmnivariateDecisionTree(max_depth=3, selection="accuracy")
+   tree.fit(X_train, y_train)
+   print(tree.get_split_type_distribution())
+
+``selection="accuracy"`` picks whichever split type scores best in
+cross-validation at that node. ``selection="test"`` instead demands that the
+more expressive split be *significantly* better by the combined 5x2cv F test,
+and otherwise keeps the simpler one. The second option is opt-in for a reason;
+see :doc:`design_decisions`.
+
+*Reference:* Yıldız, O. T. and Alpaydın, E. (2001). Omnivariate Decision Trees.
+*IEEE Transactions on Neural Networks*, 12(6), 1539–1546.
+
+Hierarchical mixture of experts
+-------------------------------
+
+A hierarchical mixture of experts is a soft tree whose leaves are models rather
+than class distributions, with gating networks routing input through the
+hierarchy. :class:`~neural_trees.HierarchicalMixtureOfExperts` implements it
+with subtree dropout, which drops whole subtrees during training so that no
+branch is relied on exclusively.
+
+.. code-block:: python
+
+   from neural_trees import HierarchicalMixtureOfExperts
+
+   moe = HierarchicalMixtureOfExperts(depth=2, dropout_rate=0.2, random_state=0)
+   moe.fit(X_train, y_train)
+
+``to_hard_router()`` exports the trained router the way ``to_hard_tree()``
+exports a soft tree.
+
+*Reference:* İrsoy, O. and Alpaydın, E. (2021). Dropout Regularization in
+Hierarchical Mixture of Experts. *Neurocomputing*, 419, 148–156.
+
+Constructive networks
+---------------------
+
+:class:`~neural_trees.GALNetwork` grows a hidden layer while it trains, adding
+units when the error stops improving and pruning units that stop contributing.
+
+.. code-block:: python
+
+   from neural_trees import GALNetwork
+
+   net = GALNetwork(max_epochs=150, growth_init="residual", random_state=0)
+   net.fit(X_train, y_train)
+   print(net.n_hidden_final_, net.architecture_history_)
+
+``growth_init`` decides how a new unit arrives. ``"random"`` is the original
+scheme. ``"residual"`` fits the candidate unit to the residual error of the
+frozen network first and installs it with zero outgoing weights, in the manner
+of cascade-correlation. On Iris over three seeds of five-fold cross-validation
+the residual variant reached 0.956 with 6.6 hidden units against 0.938 with
+17.4.
+
+*Reference:* Alpaydın, E. (1994). GAL: Networks that grow when they learn and
+shrink when they forget. *IJPRAI*, 8(1), 391–414.
+
+Classical baselines
+-------------------
+
+:class:`~neural_trees.WeightedKNN` implements condensed nearest neighbour with
+voting over several independently condensed prototype sets, which is the idea of
+the paper it cites rather than a single condensed set.
+
+:class:`~neural_trees.NaiveBayesClassifier` is a Gaussian naive Bayes with
+normalised ``predict_log_proba``.
+
+Weighting
+---------
+
+:class:`~neural_trees.SoftDecisionTree`,
+:class:`~neural_trees.HierarchicalMixtureOfExperts` and
+:class:`~neural_trees.GALNetwork` accept ``sample_weight`` in ``fit`` and a
+``class_weight`` parameter. For :class:`~neural_trees.GALNetwork` the weights
+are carried into the growth criterion as well, so that weighting changes what
+the network *builds* and not only what it learns.
+
+These three estimators fail exactly one scikit-learn check,
+``check_sample_weight_equivalence_on_dense_data``, which requires weighting a
+sample to be bit-identical to repeating it. No stochastic mini-batch learner can
+satisfy it. The other four estimators pass all 55 checks.

--- a/examples/01_iris_classification.py
+++ b/examples/01_iris_classification.py
@@ -1,4 +1,7 @@
 """
+Training a soft decision tree
+=============================
+
 Minimal end-to-end example: train a Soft Decision Tree on Iris.
 
 Run with:

--- a/examples/02_pipeline_with_scaler.py
+++ b/examples/02_pipeline_with_scaler.py
@@ -1,4 +1,7 @@
 """
+Inside a scikit-learn pipeline
+==============================
+
 Use SoftDecisionTree inside a scikit-learn Pipeline with StandardScaler,
 and report 5-fold cross-validated accuracy on the Wine dataset.
 

--- a/examples/03_classifier_comparison.py
+++ b/examples/03_classifier_comparison.py
@@ -1,4 +1,7 @@
 """
+Is the difference significant?
+==============================
+
 Compare a Soft Decision Tree against CART with Alpaydin's combined 5x2cv F test.
 
 The test asks whether the accuracy gap between the two models is larger than

--- a/examples/04_decision_boundary.py
+++ b/examples/04_decision_boundary.py
@@ -1,4 +1,7 @@
 """
+Plotting the decision boundary
+==============================
+
 Plot the decision boundary a Soft Decision Tree learns on make_moons.
 
 The boundary is smooth rather than axis-aligned and piecewise constant,
@@ -40,7 +43,12 @@ ax.scatter(X[:, 0], X[:, 1], c=y, cmap="RdBu_r", edgecolors="k", s=25)
 ax.set_title(f"SoftDecisionTree(depth=4) on make_moons, accuracy {model.score(X, y):.3f}")
 fig.colorbar(contour, ax=ax, label="P(class 1)")
 
-out_path = Path(__file__).parent / "output" / "04_decision_boundary.png"
-out_path.parent.mkdir(parents=True, exist_ok=True)
-fig.savefig(out_path, dpi=150, bbox_inches="tight")
-print(f"Saved {out_path}")
+# Writing a file only makes sense when this runs as a script. Inside the
+# documentation gallery there is no __file__ and the figure is captured directly.
+if "__file__" in globals():
+    out_path = Path(__file__).parent / "output" / "04_decision_boundary.png"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    print(f"Saved {out_path}")
+else:
+    plt.show()

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,0 +1,9 @@
+.. _examples_gallery:
+
+Examples
+========
+
+Runnable scripts covering the common tasks: training a single model, putting one
+in a pipeline, comparing several against scikit-learn's own estimators, and
+plotting a decision boundary. Each is a standalone file under ``examples/`` in
+the repository.

--- a/neural_trees/classical/k_nearest_neighbors.py
+++ b/neural_trees/classical/k_nearest_neighbors.py
@@ -47,7 +47,7 @@ class WeightedKNN(ClassifierMixin, BaseEstimator):
         (1997) builds several subsets from different orderings and combines
         their votes, which is where some of the accuracy a single subset gives
         away comes back. 5-fold accuracy averaged over 5 seeds, by number of
-        subsets, against keeping every sample:
+        subsets, against keeping every sample::
 
                             1       3       5       9     all
             Iris          0.917   0.939   0.937   0.937   0.956

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
 "Live demo" = "https://neural-trees.streamlit.app"
 Source = "https://github.com/cgrtml/neural-trees"
 "Bug Tracker" = "https://github.com/cgrtml/neural-trees/issues"
-Documentation = "https://github.com/cgrtml/neural-trees#readme"
+Documentation = "https://cagritemel.com/neural-trees/"
 
 [tool.setuptools.package-data]
 neural_trees = ["py.typed"]


### PR DESCRIPTION
Sphinx site with pydata-sphinx-theme, numpydoc API reference and a sphinx-gallery of the existing `examples/`, deployed to GitHub Pages by `.github/workflows/docs.yml`.

The build runs with `-W`, so any Sphinx warning fails CI. Docs that rot silently are worse than no docs.

### Pages

| page | what it is |
|---|---|
| `install.rst` | install, CPU-only wheel, device selection, from source |
| `user_guide.rst` | each model family, what makes it different, and the paper it comes from |
| `model_comparison.rst` | the three tests and a table for choosing between them |
| `design_decisions.rst` | every departure from the published algorithm, with the measurement behind it |
| `api.rst` | autosummary over all 12 public names |
| `auto_examples/` | the four example scripts, executed at build time |

### Source fixes this required

- The example scripts had no reST title, which sphinx-gallery requires. Each has one now.
- `04_decision_boundary.py` wrote its figure through `__file__`, which does not exist when the gallery executes the script. The write is now conditional and the gallery captures the figure directly.
- `WeightedKNN`'s docstring introduced an indented ASCII table with a single colon. reST read it as a block quote and failed to unindent from it. It is a literal block now.

### URL

Documentation links point at https://cagritemel.com/neural-trees/ rather than github.io, because the account's Pages site carries that custom domain and project pages inherit it.

Nothing is published until this merges.